### PR TITLE
Introduce sbt-assembly for shaded and provided dependencies

### DIFF
--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/ClusterBootstrap.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/ClusterBootstrap.scala
@@ -18,12 +18,10 @@ package com.lightbend.rp.akkaclusterbootstrap
 
 import akka.actor._
 import akka.cluster.Cluster
-import akka.http.scaladsl.Http
 import com.lightbend.rp.servicediscovery.scaladsl._
 
 final class ClusterBootstrapImpl(system: ExtendedActorSystem) extends Extension {
   val cluster = Cluster(system)
-  val http = Http(system)
   val serviceLocator = ServiceLocator(system)
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,61 @@
+import scala.collection.immutable.Seq
 import ReleaseTransformations._
 
 lazy val Versions = new {
   val akka              = "2.4.12" // First version cross-compiled to 2.12
-  val akkaHttp          = "10.0.10"
+  val akkaDns           = "2.4.2"
+  val dispatch          = "0.13.2"
   val lagom13           = "1.3.0"
   val lagom14           = "1.4.0-M2"
   val play25            = "2.5.0"
   val play26            = "2.6.0"
   val scala211          = "2.11.11"
   val scala212          = "2.12.3"
+  val scalaJava8Compat  = "0.8.0"
   val scalaTest         = "3.0.1"
   val serviceLocatorDns = "2.2.2"
+  val sprayJson         = "1.3.3"
+  val typesafeConfig    = "1.3.1"
 }
 
+def assemblyExcludeLocal(names: String*) =
+  assemblyOption in assembly := {
+    val options = (assemblyOption in assembly).value
+
+    options.copy(
+      excludedFiles = { files =>
+        options.excludedFiles(files) ++ files
+          .filter(_.isDirectory)
+          .map(dir => (dir, (dir ** "*").get))
+          .flatMap { case (dir, files) =>
+            names.flatMap { name =>
+              val path = Seq("com", "lightbend", "rp", name).mkString(s"${Path.sep}")
+
+              if (files.exists(_.getAbsolutePath.contains(path)))
+                dir +: files
+              else
+                Seq.empty
+            }
+          }
+      }
+    )
+  }
+
+def assemblyInclude(names: String*) =
+  assemblyExcludedJars in assembly :=
+    (fullClasspath in assembly)
+      .value
+      .filterNot(f => names.nonEmpty && names.exists(f.data.getName.startsWith))
+
+def semanticVersioningMajor(version: String) =
+  version
+    .reverse
+    .dropWhile(_ != '.')
+    .dropWhile(_ == '.')
+    .reverse
+
 def createProject(id: String, path: String) = Project(id, file(path))
-  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(AutomateHeaderPlugin, AssemblyPlugin)
   .settings(
     name := id,
     resolvers += Resolver.bintrayRepo("hajile", "maven"),
@@ -54,7 +95,16 @@ def createProject(id: String, path: String) = Project(id, file(path))
       setNextVersion,
       commitNextVersion,
       pushChanges
-    )
+    ),
+
+    addArtifact(artifact in (Compile, assembly), assembly),
+
+    assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false),
+
+    assemblyJarName in assembly :=
+      s"${name.value}_${semanticVersioningMajor(scalaVersion.value)}-${version.value}.jar",
+
+    packageBin in Compile := (assembly in Compile).value
   )
 
 lazy val root = createProject("reactive-lib", ".")
@@ -78,70 +128,138 @@ lazy val common = createProject("reactive-lib-common", "common")
     crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
   )
 
+lazy val serviceDiscoveryAssemblySettings = Vector(
+  libraryDependencies ++= Seq(
+    "com.typesafe.akka"        %% "akka-actor"          % Versions.akka              % "provided",
+    "com.typesafe"              % "config"              % Versions.typesafeConfig    % "provided",
+    "org.scala-lang.modules"   %% "scala-java8-compat"  % Versions.scalaJava8Compat  % "provided",
+    "com.lightbend"            %% "service-locator-dns" % Versions.serviceLocatorDns,
+    "ru.smslv.akka"            %% "akka-dns"            % Versions.akkaDns
+  ),
+  assemblyShadeRules in assembly ++= Seq(
+    ShadeRule.rename("akka.io.AsyncDnsResolver**" -> "com.lightbend.rp.internal.@0").inAll,
+    ShadeRule.rename("com.lightbend.dns.locator.**" -> "com.lightbend.rp.internal.@0").inAll,
+    ShadeRule.rename("ru.smslv**" -> "com.lightbend.rp.internal.@0").inAll
+  )
+)
+
 lazy val serviceDiscovery = createProject("reactive-lib-service-discovery", "service-discovery")
   .dependsOn(common)
+  .settings(serviceDiscoveryAssemblySettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.lightbend"     %% "service-locator-dns" % Versions.serviceLocatorDns
+      "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test",
     ),
-    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212),
+    assemblyInclude("akka-dns", "service-locator-dns"),
+    assemblyExcludeLocal("common")
   )
 
 lazy val serviceDiscoveryLagom13Java = createProject("reactive-lib-service-discovery-lagom13-java", "service-discovery-lagom13-java")
   .dependsOn(serviceDiscovery)
+  .settings(serviceDiscoveryAssemblySettings)
   .settings(
     autoScalaLibrary := false,
     crossPaths := false,
     libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-javadsl-client" % Versions.lagom13
-    )
+      "com.lightbend.lagom" %% "lagom-javadsl-client" % Versions.lagom13 % "provided"
+    ),
+    assemblyInclude(),
+    assemblyExcludeLocal("common", "servicediscovery")
   )
 
 lazy val serviceDiscoveryLagom13Scala = createProject("reactive-lib-service-discovery-lagom13-scala", "service-discovery-lagom13-scala")
   .dependsOn(serviceDiscovery)
+  .settings(serviceDiscoveryAssemblySettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-scaladsl-client" % Versions.lagom13
-    )
+      "com.lightbend.lagom" %% "lagom-scaladsl-client"   % Versions.lagom13 % "provided"
+    ),
+    assemblyInclude(),
+    assemblyExcludeLocal("common", "servicediscovery")
   )
 
 lazy val serviceDiscoveryLagom14Java = createProject("reactive-lib-service-discovery-lagom14-java", "service-discovery-lagom14-java")
   .dependsOn(serviceDiscovery)
+  .settings(serviceDiscoveryAssemblySettings)
   .settings(
     autoScalaLibrary := false,
     crossPaths := false,
     libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-javadsl-client" % Versions.lagom14
-    )
+      "com.lightbend.lagom" %% "lagom-javadsl-client" % Versions.lagom14 % "provided"
+    ),
+    assemblyInclude(),
+    assemblyExcludeLocal("common", "servicediscovery")
   )
 
 lazy val serviceDiscoveryLagom14Scala = createProject("reactive-lib-service-discovery-lagom14-scala", "service-discovery-lagom14-scala")
   .dependsOn(serviceDiscovery)
+  .settings(serviceDiscoveryAssemblySettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-scaladsl-client" % Versions.lagom14
-    )
+      "com.lightbend.lagom" %% "lagom-scaladsl-client" % Versions.lagom14 % "provided",
+    ),
+    assemblyInclude(),
+    assemblyExcludeLocal("common", "servicediscovery")
   )
 
 lazy val akkaClusterBootstrap = createProject("reactive-lib-akka-cluster-bootstrap", "akka-cluster-bootstrap")
   .dependsOn(serviceDiscovery)
+  .settings(serviceDiscoveryAssemblySettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor"          % Versions.akka,
-      "com.typesafe.akka" %% "akka-cluster"        % Versions.akka,
-      "com.typesafe.akka" %% "akka-http"           % Versions.akkaHttp
+      "com.typesafe.akka"       %% "akka-cluster"        % Versions.akka      % "provided",
+      "net.databinder.dispatch" %% "dispatch-core"       % Versions.dispatch,
+      "io.spray"                %% "spray-json"          % Versions.sprayJson
     ),
-    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212),
+    assemblyShadeRules in assembly ++= Seq(
+      ShadeRule.rename("com.typesafe.netty.**" -> "com.lightbend.rp.internal.@0").inAll,
+      ShadeRule.rename("dispatch.**" -> "com.lightbend.rp.internal.@0").inAll,
+      ShadeRule.rename("io.netty.**" -> "com.lightbend.rp.internal.@0").inAll,
+      ShadeRule.rename("org.asynchttpclient**" -> "com.lightbend.rp.internal.@0").inAll,
+      ShadeRule.rename("org.reactivestreams**" -> "com.lightbend.rp.internal.@0").inAll,
+      ShadeRule.rename("org.slf4j**" -> "com.lightbend.rp.internal.@0").inAll,
+      ShadeRule.rename("spray.**" -> "com.lightbend.rp.internal.@0").inAll
+    ),
+    assemblyMergeStrategy in assembly := {
+      case PathList(ps @ _*) if ps.last == "io.netty.versions.properties" =>
+        MergeStrategy.first
+      case x =>
+        val oldStrategy = (assemblyMergeStrategy in assembly).value
+        oldStrategy(x)
+    },
+    assemblyExcludeLocal("common", "servicediscovery"),
+    assemblyInclude(
+      "async-http-client",
+      "async-http-client-netty-utils",
+      "dispatch-core",
+      "netty-buffer",
+      "netty-codec",
+      "netty-codec-dns",
+      "netty-codec-http",
+      "netty-common",
+      "netty-handler",
+      "netty-reactive-streams",
+      "netty-resolver",
+      "netty-resolver-dns",
+      "netty-transport",
+      "netty-transport-native-epoll",
+      "reactive-streams",
+      "slf4j-api",
+      "spray-json")
   )
 
 lazy val playHttpBinding = createProject("reactive-lib-play-http-binding", "play-http-binding")
   .dependsOn(common)
   .settings(
-    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212),
+    assemblyExcludeLocal("common")
   )
 
 lazy val secrets = createProject("reactive-lib-secrets", "secrets")
   .dependsOn(common)
   .settings(
-    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212),
+    assemblyExcludeLocal("common")
   )

--- a/common/src/main/scala/com/lightbend/rp/common/Platform.scala
+++ b/common/src/main/scala/com/lightbend/rp/common/Platform.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp
+package com.lightbend.rp.common
 
 sealed trait Platform
 

--- a/common/src/test/scala/com/lightbend/rp/common/PlatformSpec.scala
+++ b/common/src/test/scala/com/lightbend/rp/common/PlatformSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp
+package com.lightbend.rp.common
 
 import org.scalatest.{Matchers, WordSpec}
 

--- a/play-http-binding/src/main/resources/play/reference-overrides.conf
+++ b/play-http-binding/src/main/resources/play/reference-overrides.conf
@@ -4,7 +4,7 @@ play {
   server {
     # See sbt-reactive-app and reactive-cli to understand where these values come from
 
-    http.address=${?RP_ENDPOINTS_0_BIND_HOST}
-    http.port=${?RP_ENDPOINTS_0_BIND_PORT}
+    http.address = ${?RP_ENDPOINTS_0_BIND_HOST}
+    http.port = ${?RP_ENDPOINTS_0_BIND_PORT}
   }
 }

--- a/project/AdditionalIO.scala
+++ b/project/AdditionalIO.scala
@@ -1,0 +1,9 @@
+import scala.sys.process._
+
+object AdditionalIO {
+  def runProcess(args: String*): Unit = {
+    val code = args.!
+
+    assert(code == 0, s"Executing $args yielded $code, expected 0")
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "3.0.2")
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly" % "0.14.5")
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.6")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.1.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.0")
-

--- a/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.servicediscovery.scaladsl
+package com.lightbend.rp.servicediscovery.lagom.scaladsl
 
 import akka.actor.ActorSystem
+import com.lightbend.lagom.internal.client.CircuitBreakers
 import com.lightbend.lagom.scaladsl.api.Descriptor
-import com.lightbend.lagom.scaladsl.client.{ CircuitBreakersPanel, CircuitBreakingServiceLocator }
-import java.net.{ URI => JavaURI }
-import scala.concurrent.{ ExecutionContext, Future }
+import com.lightbend.lagom.scaladsl.client.CircuitBreakingServiceLocator
+import java.net.{URI => JavaURI}
+
+import com.lightbend.rp.servicediscovery.scaladsl.ServiceLocator
+
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.reflectiveCalls
 
-class LagomServiceLocator(circuitBreakersPanel: CircuitBreakersPanel)
-                         (implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakersPanel)(ec) {
+class LagomServiceLocator(circuitBreakers: CircuitBreakers)
+                         (implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakers)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
     ServiceLocator.lookup(name)

--- a/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.servicediscovery.scaladsl
+package com.lightbend.rp.servicediscovery.lagom.scaladsl
 
 import akka.actor.ActorSystem
-import com.lightbend.lagom.internal.client.CircuitBreakers
 import com.lightbend.lagom.scaladsl.api.Descriptor
-import com.lightbend.lagom.scaladsl.client.CircuitBreakingServiceLocator
-import java.net.{ URI => JavaURI }
-import scala.concurrent.{ ExecutionContext, Future }
+import com.lightbend.lagom.scaladsl.client.{CircuitBreakersPanel, CircuitBreakingServiceLocator}
+import java.net.{URI => JavaURI}
+import com.lightbend.rp.servicediscovery.scaladsl.ServiceLocator
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.reflectiveCalls
 
-class LagomServiceLocator(circuitBreakers: CircuitBreakers)
-                         (implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakers)(ec) {
+class LagomServiceLocator(circuitBreakersPanel: CircuitBreakersPanel)
+                         (implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakersPanel)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
     ServiceLocator.lookup(name)

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
@@ -19,7 +19,7 @@ package com.lightbend.rp.servicediscovery.scaladsl
 import akka.actor._
 import akka.pattern.ask
 import com.lightbend.dns.locator.{ ServiceLocator => DnsServiceLocator, Settings => DnsServiceLocatorSettings }
-import com.lightbend.rp._
+import com.lightbend.rp.common._
 import java.net.URI
 import scala.concurrent.Future
 


### PR DESCRIPTION
**WIP: I'd like to manually test netty to make sure it's working.**

This PR includes `sbt-assembly` and uses it to provide shaded dependencies of `spray-json` and `dispatch` (and it's dependencies like `netty`).

This means that when jars are built, the bytecode is rewritten so that e.g. `io.netty` becomes `com.lightbend.rp.internal.io.netty`.