### PR TITLE
Service Discovery External Services 

### DIFF
--- a/service-discovery/src/main/java/com/lightbend/rp/servicediscovery/javadsl/AddressSelection.java
+++ b/service-discovery/src/main/java/com/lightbend/rp/servicediscovery/javadsl/AddressSelection.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.servicediscovery.javadsl;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+public interface AddressSelection {
+    Optional<URI> select(List<URI> addreses);
+}

--- a/service-discovery/src/main/resources/reference.conf
+++ b/service-discovery/src/main/resources/reference.conf
@@ -1,5 +1,9 @@
-reactive-lib {
+rp {
   service-discovery {
     ask-timeout = 1 second
+
+    external-service-addresses {
+      # "some-service" = ["http://127.0.0.1:9000", "http://127.0.0.1:9001"]
+    }
   }
 }

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Settings.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Settings.scala
@@ -18,13 +18,26 @@ package com.lightbend.rp.servicediscovery.scaladsl
 
 import akka.actor._
 import com.typesafe.config.Config
-
+import java.net.URI
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
 import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS}
 
 final class SettingsImpl(system: ExtendedActorSystem) extends Extension {
-  private val serviceDiscovery = system.settings.config.getConfig("reactive-lib.service-discovery")
+  private val serviceDiscovery = system.settings.config.getConfig("rp.service-discovery")
 
   val askTimeout: FiniteDuration = duration(serviceDiscovery, "ask-timeout")
+
+  val externalServiceAddresses: Map[String, Seq[URI]] = {
+    val data = serviceDiscovery.getObject("external-service-addresses")
+    val config = data.toConfig
+
+    data
+      .keySet()
+      .asScala
+      .map(k => k -> config.getStringList(k).asScala.toVector.map(new URI(_)))
+      .toMap
+  }
 
   private def duration(config: Config, key: String): FiniteDuration =
     Duration(config.getDuration(key, MILLISECONDS), MILLISECONDS)

--- a/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/javadsl/ServiceLocatorSpec.scala
+++ b/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/javadsl/ServiceLocatorSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.servicediscovery.javadsl
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import com.lightbend.rp.servicediscovery.scaladsl.Settings
+import com.typesafe.config.ConfigFactory
+import java.net.URI
+import java.util.Optional
+import org.scalatest.{AsyncWordSpecLike, BeforeAndAfterAll, Matchers}
+import scala.collection.JavaConversions._
+import scala.collection.immutable.Seq
+
+object ServiceLocatorSpec {
+  def config = ConfigFactory
+    .parseString(
+      s"""|rp.service-discovery {
+          |  external-service-addresses {
+          |    "has-one" = ["http://127.0.0.1:9000"]
+          |    "has-two" = ["http://127.0.0.1:8000", "http://127.0.0.1:8001"]
+          |  }
+          |}
+          |""".stripMargin)
+    .withFallback(ConfigFactory.defaultApplication())
+}
+
+class ServiceLocatorSpec extends TestKit(ActorSystem("service-locator", ServiceLocatorSpec.config))
+  with ImplicitSender
+  with AsyncWordSpecLike
+  with Matchers
+  with BeforeAndAfterAll {
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val settings = Settings(system)
+
+  "addressSelectionFirst" should {
+    "work for empty lists" in {
+      ServiceLocator.addressSelectionFirst.select(Seq()) shouldBe Optional.empty[URI]()
+    }
+
+    "work for non-empty lists" in {
+      ServiceLocator.addressSelectionFirst.select(
+        Seq(
+          new URI("http://127.0.0.1:9000"),
+          new URI("http://127.0.0.1:9001"))).get() shouldBe new URI("http://127.0.0.1:9000")
+    }
+  }
+
+  "addressSelectionRandom" should {
+    "work for empty lists" in {
+      ServiceLocator.addressSelectionFirst.select(Seq()) shouldBe Optional.empty[URI]()
+    }
+
+    "work for non-empty lists" in {
+      ServiceLocator.addressSelectionFirst.select(Seq(new URI("http://127.0.0.1:9000"))).isPresent shouldBe true
+    }
+  }
+}

--- a/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
+++ b/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.servicediscovery.scaladsl
+
+import akka.actor.ActorSystem
+import akka.testkit.{ ImplicitSender, TestKit }
+import com.typesafe.config.ConfigFactory
+import java.net.URI
+import org.scalatest.{ AsyncWordSpecLike, BeforeAndAfterAll, Matchers }
+import scala.collection.immutable.Seq
+
+object ServiceLocatorSpec {
+  def config = ConfigFactory
+    .parseString(
+      s"""|rp.service-discovery {
+          |  external-service-addresses {
+          |    "has-one" = ["http://127.0.0.1:9000"]
+          |    "has-two" = ["http://127.0.0.1:8000", "http://127.0.0.1:8001"]
+          |  }
+          |}
+          |""".stripMargin)
+    .withFallback(ConfigFactory.defaultApplication())
+}
+
+class ServiceLocatorSpec extends TestKit(ActorSystem("service-locator", ServiceLocatorSpec.config))
+  with ImplicitSender
+  with AsyncWordSpecLike
+  with Matchers
+  with BeforeAndAfterAll {
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val settings = Settings(system)
+
+  "AddressSelectionFirst" should {
+    "work for empty sequences" in {
+      ServiceLocator.AddressSelectionFirst(Seq.empty) shouldBe None
+    }
+
+    "work for non-empty sequences" in {
+      ServiceLocator.AddressSelectionFirst(
+        Seq(new URI("http://127.0.0.1:9000"))).contains(new URI("http://127.0.0.1:9000")) shouldBe true
+
+      ServiceLocator.AddressSelectionFirst(
+        Seq(
+          new URI("http://127.0.0.1:9000"),
+          new URI("http://127.0.0.1:9001"))).contains(new URI("http://127.0.0.1:9000")) shouldBe true
+    }
+  }
+
+  "AddressSelectionRandom" should {
+    "work for empty sequences" in {
+      ServiceLocator.AddressSelectionRandom(Seq.empty) shouldBe None
+    }
+
+    "work for non-empty sequences" in {
+      ServiceLocator.AddressSelectionRandom(
+        Seq(new URI("http://127.0.0.1:9000"))).contains(new URI("http://127.0.0.1:9000")) shouldBe true
+
+      ServiceLocator.AddressSelectionRandom(
+        Seq(new URI("http://127.0.0.1:9000"), new URI("http://127.0.0.1:9001"))).nonEmpty shouldBe true
+    }
+  }
+
+  "ServiceLocator" should {
+    "resolve external services correctly (one)" in {
+      ServiceLocator
+        .lookup("has-one")
+        .map(_.contains(new URI("http://127.0.0.1:9000")) shouldBe true)
+    }
+
+    "resolve external services correctly (many #1)" in {
+      ServiceLocator
+        .lookup("has-two", _.headOption)
+        .map(_.contains(new URI("http://127.0.0.1:8000")) shouldBe true)
+    }
+
+    "resolve external services correctly (many #2)" in {
+      ServiceLocator
+        .lookup("has-two", _.lastOption)
+        .map(_.contains(new URI("http://127.0.0.1:8001")) shouldBe true)
+    }
+  }
+}


### PR DESCRIPTION
This PR allows the service discovery component to accept external services declared via properties.

For instance,

`java ... -Drp.service-discovery.external-service-addresses.my-service-name-v1.0=http://127.0.0.1:7000`