### PR TITLE
More updates

### DIFF
--- a/akka-cluster-bootstrap/src/main/resources/application.conf
+++ b/akka-cluster-bootstrap/src/main/resources/application.conf
@@ -11,11 +11,11 @@ akka {
 
   remote {
     netty.tcp {
-      hostname = ${?RP_ENDPOINTS_AKKA_REMOTE_HOST}
-      port = ${?RP_ENDPOINTS_AKKA_REMOTE_HOST}
+      hostname = ${?RP_ENDPOINT_AKKA_REMOTE_HOST}
+      port = ${?RP_ENDPOINT_AKKA_REMOTE_HOST}
 
-      bind-hostname = ${?RP_ENDPOINTS_AKKA_REMOTE_BIND_HOST}
-      bind-port = ${?RP_ENDPOINTS_AKKA_REMOTE_BIND_HOST}
+      bind-hostname = ${?RP_ENDPOINT_AKKA_REMOTE_BIND_HOST}
+      bind-port = ${?RP_ENDPOINT_AKKA_REMOTE_BIND_HOST}
     }
   }
 }

--- a/akka-cluster-bootstrap/src/main/resources/reference.conf
+++ b/akka-cluster-bootstrap/src/main/resources/reference.conf
@@ -17,6 +17,9 @@ rp.akka-cluster-bootstrap {
   # Name to find registrar in for service discovery
   registrar-service-name = "rp-registrar"
 
+  # Name of registrar's endpoint for service discovery
+  registrar-endpoint-name = "http"
+
   # Pattern for creating the topic. %s will be replaced with the actor system name
   registrar-topic-pattern = "akka-cluster[%s]"
 }

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/Settings.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/Settings.scala
@@ -33,6 +33,7 @@ class Settings private (system: ExtendedActorSystem) extends Extension {
   val registrarRegistrationAttempts: Int = settings.getInt("registrar-registration-attempts")
   val registrarRegistrationFailTimeout: FiniteDuration = duration(settings, "registrar-registration-fail-timeout")
   val registrarServiceName: String = settings.getString("registrar-service-name")
+  val registrarEndpointName: String = settings.getString("registrar-endpoint-name")
   val registrarTopicPattern: String = settings.getString("registrar-topic-pattern")
 
   private def duration(config: Config, key: String): FiniteDuration =

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/registrar/Client.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/registrar/Client.scala
@@ -106,10 +106,10 @@ class DispatchClient(system: ActorSystem) extends Client {
 
   private def findRegistrar() =
     ServiceLocator
-      .lookupOne(settings.registrarServiceName)
+      .lookupOne(settings.registrarServiceName, settings.registrarEndpointName)
       .filter { uri =>
         if (uri.isEmpty) {
-          system.log.error(s"Unable to find registrar: ${settings.registrarServiceName}")
+          system.log.error(s"Unable to find registrar: ${settings.registrarServiceName} ${settings.registrarEndpointName}")
         }
 
         uri.nonEmpty

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/registrar/Client.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/registrar/Client.scala
@@ -106,7 +106,7 @@ class DispatchClient(system: ActorSystem) extends Client {
 
   private def findRegistrar() =
     ServiceLocator
-      .lookup(settings.registrarServiceName)
+      .lookupOne(settings.registrarServiceName)
       .filter { uri =>
         if (uri.isEmpty) {
           system.log.error(s"Unable to find registrar: ${settings.registrarServiceName}")

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/registrar/Client.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/registrar/Client.scala
@@ -114,5 +114,5 @@ class DispatchClient(system: ActorSystem) extends Client {
 
         uri.nonEmpty
       }
-      .map(uri => Req(_.setUrl(RawUri(uri.get).toString)))
+      .map(service => Req(_.setUrl(RawUri(service.get.uri).toString)))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,12 @@ lazy val Versions = new {
   val typesafeConfig    = "1.3.1"
 }
 
+/**
+ * This method excludes any files with a subdirectory sequence of `names` in the path. This
+ * is used to ensure that local project files from dependencies don't end up in the assembled
+ * jar. For instance, you call this with "common" to ensure no "com/lightbend/rp/common"
+ * directories end up in your jar.
+ */
 def assemblyExcludeLocal(names: Seq[String]*) =
   assemblyOption in assembly := {
     val options = (assemblyOption in assembly).value

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ lazy val Versions = new {
   val scala212          = "2.12.3"
   val scalaJava8Compat  = "0.8.0"
   val scalaTest         = "3.0.1"
-  val serviceLocatorDns = "2.2.2"
   val sprayJson         = "1.3.3"
   val typesafeConfig    = "1.3.1"
 }
@@ -139,12 +138,10 @@ lazy val serviceDiscoveryAssemblySettings = Vector(
     "com.typesafe.akka"        %% "akka-actor"          % Versions.akka              % "provided",
     "com.typesafe"              % "config"              % Versions.typesafeConfig    % "provided",
     "org.scala-lang.modules"   %% "scala-java8-compat"  % Versions.scalaJava8Compat  % "provided",
-    "com.lightbend"            %% "service-locator-dns" % Versions.serviceLocatorDns,
     "ru.smslv.akka"            %% "akka-dns"            % Versions.akkaDns
   ),
   assemblyShadeRules in assembly ++= Seq(
     ShadeRule.rename("akka.io.AsyncDnsResolver**" -> "com.lightbend.rp.internal.@0").inAll,
-    ShadeRule.rename("com.lightbend.dns.locator.**" -> "com.lightbend.rp.internal.@0").inAll,
     ShadeRule.rename("ru.smslv**" -> "com.lightbend.rp.internal.@0").inAll
   )
 )
@@ -157,7 +154,7 @@ lazy val serviceDiscovery = createProject("reactive-lib-service-discovery", "ser
       "com.typesafe.akka" %% "akka-testkit" % Versions.akka % "test",
     ),
     crossScalaVersions := Vector(Versions.scala211, Versions.scala212),
-    assemblyInclude("akka-dns", "service-locator-dns"),
+    assemblyInclude("akka-dns"),
     assemblyExcludeLocal(Seq("common"))
   )
 

--- a/common/src/main/scala/com/lightbend/rp/common/SocketBinding.scala
+++ b/common/src/main/scala/com/lightbend/rp/common/SocketBinding.scala
@@ -30,9 +30,9 @@ object SocketBinding {
 
   def port(name: String, default: Int): Int = reader.port(name, default)
 
-  private[common] class EnvironmentReader(environment: Map[String, String]) {
-    private val VersionSeparator = "-v"
+  def protocol(name: String): Option[SocketProtocol] = reader.protocol(name)
 
+  private[common] class EnvironmentReader(environment: Map[String, String]) {
     private val ValidEndpointChars =
       (('0' to '9') ++ ('A' to 'Z') ++ Seq('_', '-')).toSet
 
@@ -54,42 +54,24 @@ object SocketBinding {
     def port(name: String, default: Int): Int =
       environment.get(assembleName(name, "PORT")).fold(default)(_.toInt)
 
+    def protocol(name: String): Option[SocketProtocol] =
+      environment
+        .get(assembleName(name, "PROTOCOL"))
+        .flatMap {
+          case "http" => Some(HttpSocketProtocol)
+          case "tcp" => Some(TcpSocketProtocol)
+          case "udp" => Some(UdpSocketProtocol)
+          case _ => None
+        }
+
     val all: Seq[String] =
       environment
         .getOrElse("RP_ENDPOINTS", "")
         .split(',')
         .toVector
 
-    val namesAndVersions: Seq[(String, Option[String])] =
-      all.map { name =>
-        val parts = name
-          .reverse
-          .split(VersionSeparator.toUpperCase.reverse, 2)
-          .map(_.reverse)
-
-        if (parts.length == 2)
-          parts(1) -> Some(parts(0))
-        else
-          parts(0) -> None
-      }
-
-    private def assembleName(name: String, suffix: String): String = {
-      val normalized = normalizeEndpointName(name)
-
-      val fullName =
-        if (all.contains(normalized))
-          normalized
-        else
-          namesAndVersions
-            .find(_._1 == normalized)
-            .map {
-              case (n, Some(v)) => s"$n${VersionSeparator.toUpperCase}$v"
-              case (n, None) => n
-            }
-            .getOrElse(normalized)
-
-      s"RP_ENDPOINT_${fullName}_$suffix"
-    }
+    private def assembleName(name: String, suffix: String): String =
+      s"RP_ENDPOINT_${normalizeEndpointName(name)}_$suffix"
 
     private def normalizeEndpointName(endpointName: String): String =
       endpointName

--- a/common/src/main/scala/com/lightbend/rp/common/SocketProtocol.scala
+++ b/common/src/main/scala/com/lightbend/rp/common/SocketProtocol.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.common
+
+sealed trait SocketProtocol
+
+case object HttpSocketProtocol extends SocketProtocol
+
+case object TcpSocketProtocol extends SocketProtocol
+
+case object UdpSocketProtocol extends SocketProtocol

--- a/common/src/test/scala/com/lightbend/rp/common/SocketBindingSpec.scala
+++ b/common/src/test/scala/com/lightbend/rp/common/SocketBindingSpec.scala
@@ -21,23 +21,31 @@ import org.scalatest.{ Matchers, WordSpec }
 class SocketBindingSpec extends WordSpec with Matchers {
   val reader = new SocketBinding.EnvironmentReader(
     Map(
-      "RP_ENDPOINTS" -> "EP0-V9,EP1-V10",
-      "RP_ENDPOINT_EP0-V9_PORT" -> "443",
-      "RP_ENDPOINT_EP1-V10_PORT" -> "80",
-      "RP_ENDPOINT_EP1-V10_BIND_PORT" -> "81",
-      "RP_ENDPOINT_EP0-V9_HOST" -> "192.168.1.5",
-      "RP_ENDPOINT_EP1-V10_HOST" -> "192.168.1.10",
-      "RP_ENDPOINT_EP1-V10_BIND_HOST" -> "0.0.0.0"))
+      "RP_ENDPOINTS" -> "EP0,EP1,EP2",
+      "RP_ENDPOINT_EP0_PORT" -> "443",
+      "RP_ENDPOINT_EP0_PROTOCOL" -> "tcp",
+      "RP_ENDPOINT_EP1_PORT" -> "80",
+      "RP_ENDPOINT_EP1_BIND_PORT" -> "81",
+      "RP_ENDPOINT_EP0_HOST" -> "192.168.1.5",
+      "RP_ENDPOINT_EP1_HOST" -> "192.168.1.10",
+      "RP_ENDPOINT_EP1_BIND_HOST" -> "0.0.0.0",
+      "RP_ENDPOINT_EP1_PROTOCOL" -> "http",
+      "RP_ENDPOINT_EP2_PORT" -> "80",
+      "RP_ENDPOINT_EP2_BIND_PORT" -> "181",
+      "RP_ENDPOINT_EP2_HOST" -> "192.168.11.5",
+      "RP_ENDPOINT_EP2_HOST" -> "192.168.11.10",
+      "RP_ENDPOINT_EP2_BIND_HOST" -> "0.0.0.0",
+      "RP_ENDPOINT_EP2_PROTOCOL" -> "udp"))
 
   "bindHost" should {
     "fallback to host when missing" in {
       reader.bindHost("ep0", "localhost") shouldBe "192.168.1.5"
-      reader.bindHost("ep0-v9", "localhost") shouldBe "192.168.1.5"
+      reader.bindHost("ep0", "localhost") shouldBe "192.168.1.5"
     }
 
     "work when present" in {
       reader.bindHost("ep1", "localhost") shouldBe "0.0.0.0"
-      reader.bindHost("ep1-v10", "localhost") shouldBe "0.0.0.0"
+      reader.bindHost("ep1", "localhost") shouldBe "0.0.0.0"
     }
 
     "fallback to default when both missing" in {
@@ -48,9 +56,9 @@ class SocketBindingSpec extends WordSpec with Matchers {
   "host" should {
     "work when present" in {
       reader.host("ep0", "localhost") shouldBe "192.168.1.5"
-      reader.host("ep0-v9", "localhost") shouldBe "192.168.1.5"
+      reader.host("ep0", "localhost") shouldBe "192.168.1.5"
       reader.host("ep1", "localhost") shouldBe "192.168.1.10"
-      reader.host("ep1-v10", "localhost") shouldBe "192.168.1.10"
+      reader.host("ep1", "localhost") shouldBe "192.168.1.10"
     }
 
     "fallback to default when both missing" in {
@@ -61,12 +69,12 @@ class SocketBindingSpec extends WordSpec with Matchers {
   "bindPort" should {
     "fallback to port when missing" in {
       reader.bindPort("ep0", 123) shouldBe 443
-      reader.bindPort("ep0-v9", 123) shouldBe 443
+      reader.bindPort("ep0", 123) shouldBe 443
     }
 
     "work when present" in {
       reader.bindPort("ep1", 456) shouldBe 81
-      reader.bindPort("ep1-v10", 456) shouldBe 81
+      reader.bindPort("ep1", 456) shouldBe 81
     }
 
     "fallback to default when both missing" in {
@@ -77,18 +85,36 @@ class SocketBindingSpec extends WordSpec with Matchers {
   "port" should {
     "fallback to port when missing" in {
       reader.port("ep0", 123) shouldBe 443
-      reader.port("ep0-v9", 123) shouldBe 443
+      reader.port("ep0", 123) shouldBe 443
       reader.port("ep1", 123) shouldBe 80
-      reader.port("ep1-v10", 123) shouldBe 80
+      reader.port("ep1", 123) shouldBe 80
     }
 
     "work when present" in {
       reader.port("ep1", 456) shouldBe 80
-      reader.port("ep1-v10", 456) shouldBe 80
+      reader.port("ep1", 456) shouldBe 80
     }
 
     "fallback to default when both missing" in {
       reader.port("ep3", 789) shouldBe 789
+    }
+  }
+
+  "protocol" should {
+    "work for udp" in {
+      reader.protocol("ep2").contains(UdpSocketProtocol) shouldBe true
+    }
+
+    "work for tcp" in {
+      reader.protocol("ep0").contains(TcpSocketProtocol) shouldBe true
+    }
+
+    "work for http" in {
+      reader.protocol("ep1").contains(HttpSocketProtocol) shouldBe true
+    }
+
+    "work for others" in {
+      reader.protocol("donkey").isEmpty shouldBe true
     }
   }
 }

--- a/service-discovery-lagom13-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
+++ b/service-discovery-lagom13-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
@@ -20,10 +20,13 @@ import akka.actor.ActorSystem;
 import com.lightbend.lagom.internal.client.CircuitBreakers;
 import com.lightbend.lagom.javadsl.api.Descriptor;
 import com.lightbend.lagom.javadsl.client.CircuitBreakingServiceLocator;
+import com.lightbend.rp.servicediscovery.scaladsl.Service;
+
 import javax.inject.Inject;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 public class LagomServiceLocator extends CircuitBreakingServiceLocator {
     private final ActorSystem actorSystem;
@@ -37,6 +40,18 @@ public class LagomServiceLocator extends CircuitBreakingServiceLocator {
 
     @Override
     public CompletionStage<Optional<URI>> locate(String name, Descriptor.Call<?, ?> serviceCall) {
-        return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator.lookup(name, "lagom-api", actorSystem);
+        return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator
+                .lookup(name, "lagom-api", actorSystem)
+                .thenApply(new Function<Optional<Service>, Optional<URI>>() {
+                    @Override
+                    public Optional<URI> apply(Optional<Service> service) {
+                        return service.map(new Function<Service, URI>() {
+                            @Override
+                            public URI apply(Service service) {
+                                return service.uri();
+                            }
+                        });
+                    }
+                });
     }
 }

--- a/service-discovery-lagom13-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
+++ b/service-discovery-lagom13-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
@@ -37,6 +37,6 @@ public class LagomServiceLocator extends CircuitBreakingServiceLocator {
 
     @Override
     public CompletionStage<Optional<URI>> locate(String name, Descriptor.Call<?, ?> serviceCall) {
-        return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator.lookup(name, actorSystem);
+        return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator.lookup(name, "lagom-api", actorSystem);
     }
 }

--- a/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -30,5 +30,5 @@ import scala.language.reflectiveCalls
 class LagomServiceLocator(circuitBreakers: CircuitBreakers)(implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakers)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
-    ServiceLocator.lookup(name)
+    ServiceLocator.lookupOne(name)
 }

--- a/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -30,5 +30,7 @@ import scala.language.reflectiveCalls
 class LagomServiceLocator(circuitBreakers: CircuitBreakers)(implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakers)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
-    ServiceLocator.lookupOne(name, "lagom-api")
+    ServiceLocator
+      .lookupOne(name, "lagom-api")
+      .map(_.map(_.uri))
 }

--- a/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -30,5 +30,5 @@ import scala.language.reflectiveCalls
 class LagomServiceLocator(circuitBreakers: CircuitBreakers)(implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakers)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
-    ServiceLocator.lookupOne(name)
+    ServiceLocator.lookupOne(name, "lagom-api")
 }

--- a/service-discovery-lagom14-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
+++ b/service-discovery-lagom14-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
@@ -37,6 +37,6 @@ public class LagomServiceLocator extends CircuitBreakingServiceLocator {
 
     @Override
     public CompletionStage<Optional<URI>> locate(String name, Descriptor.Call<?, ?> serviceCall) {
-        return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator.lookup(name, actorSystem);
+        return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator.lookup(name, "lagom-api", actorSystem);
     }
 }

--- a/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -27,5 +27,5 @@ import scala.language.reflectiveCalls
 class LagomServiceLocator(circuitBreakersPanel: CircuitBreakersPanel)(implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakersPanel)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
-    ServiceLocator.lookup(name)
+    ServiceLocator.lookupOne(name)
 }

--- a/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -27,5 +27,7 @@ import scala.language.reflectiveCalls
 class LagomServiceLocator(circuitBreakersPanel: CircuitBreakersPanel)(implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakersPanel)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
-    ServiceLocator.lookupOne(name, "lagom-api")
+    ServiceLocator
+      .lookupOne(name, "lagom-api")
+      .map(_.map(_.uri))
 }

--- a/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
+++ b/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocator.scala
@@ -27,5 +27,5 @@ import scala.language.reflectiveCalls
 class LagomServiceLocator(circuitBreakersPanel: CircuitBreakersPanel)(implicit as: ActorSystem, ec: ExecutionContext) extends CircuitBreakingServiceLocator(circuitBreakersPanel)(ec) {
 
   override def locate(name: String, serviceCall: Descriptor.Call[_, _]): Future[Option[JavaURI]] =
-    ServiceLocator.lookupOne(name)
+    ServiceLocator.lookupOne(name, "lagom-api")
 }

--- a/service-discovery/src/main/java/com/lightbend/rp/servicediscovery/javadsl/ServiceLocator.java
+++ b/service-discovery/src/main/java/com/lightbend/rp/servicediscovery/javadsl/ServiceLocator.java
@@ -44,15 +44,17 @@ public final class ServiceLocator {
             Optional.empty() :
             Optional.of(addreses.get(ThreadLocalRandom.current().nextInt(addreses.size())));
 
-    public static CompletionStage<Optional<URI>> lookup(String name, ActorSystem actorSystem) {
-        return lookup(name, actorSystem, addressSelectionRandom);
+    public static CompletionStage<Optional<URI>> lookup(String name, String endpoint, ActorSystem actorSystem) {
+        return lookup(name, endpoint, actorSystem, addressSelectionRandom);
     }
 
-    public static CompletionStage<Optional<URI>> lookup(String name, ActorSystem actorSystem, AddressSelection addressSelection) {
+    public static CompletionStage<Optional<URI>> lookup(String name, String endpoint, ActorSystem actorSystem, AddressSelection addressSelection) {
         return FutureConverters.toJava(
                 ServiceLocator$
                         .MODULE$
-                        .lookupOne(name,
+                        .lookupOne(
+                                name,
+                                endpoint,
                                 new AbstractFunction1<Seq<URI>, Option<URI>>() {
                                     @Override
                                     public Option<URI> apply(Seq<URI> addresses) {

--- a/service-discovery/src/main/java/com/lightbend/rp/servicediscovery/javadsl/ServiceLocator.java
+++ b/service-discovery/src/main/java/com/lightbend/rp/servicediscovery/javadsl/ServiceLocator.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import scala.runtime.AbstractFunction1;
 import scala.Option;
 import scala.collection.JavaConversions;
-import scala.collection.Seq;
+import scala.collection.immutable.Seq;
 import scala.compat.java8.FutureConverters;
 
 public final class ServiceLocator {
@@ -52,7 +52,7 @@ public final class ServiceLocator {
         return FutureConverters.toJava(
                 ServiceLocator$
                         .MODULE$
-                        .lookup(name,
+                        .lookupOne(name,
                                 new AbstractFunction1<Seq<URI>, Option<URI>>() {
                                     @Override
                                     public Option<URI> apply(Seq<URI> addresses) {

--- a/service-discovery/src/main/resources/reference.conf
+++ b/service-discovery/src/main/resources/reference.conf
@@ -3,7 +3,9 @@ rp {
     ask-timeout = 1 second
 
     external-service-addresses {
-      "some-service" = ["http://127.0.0.1:9000", "http://127.0.0.1:9001"]
+    #  "my-service/my-endpoint" {
+    #    ["http://127.0.0.1:9000", "http://127.0.0.1:9001", "friendservice/lagom-api"]
+    #  }
     }
 
     external-service-address-limit = 3

--- a/service-discovery/src/main/resources/reference.conf
+++ b/service-discovery/src/main/resources/reference.conf
@@ -3,7 +3,9 @@ rp {
     ask-timeout = 1 second
 
     external-service-addresses {
-      # "some-service" = ["http://127.0.0.1:9000", "http://127.0.0.1:9001"]
+      "some-service" = ["http://127.0.0.1:9000", "http://127.0.0.1:9001"]
     }
+
+    external-service-address-limit = 3
   }
 }

--- a/service-discovery/src/main/resources/reference.conf
+++ b/service-discovery/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ rp {
 
     external-service-addresses {
     #  "my-service/my-endpoint" {
-    #    ["http://127.0.0.1:9000", "http://127.0.0.1:9001", "friendservice/lagom-api"]
+    #    ["http://127.0.0.1:9000", "http://127.0.0.1:9001", "friendservice/lagom-http-api"]
     #  }
     }
 

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Service.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Service.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.servicediscovery.scaladsl
+
+import java.net.URI
+
+case class Service(hostname: String, uri: URI)

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
@@ -66,8 +66,6 @@ object ServiceLocator {
       protocol
 
   private def doLookup(name: String, endpoint: String, externalChecks: Int)(implicit as: ActorSystem): Future[Seq[Service]] = {
-    println(s"doLookup($name, $endpoint, $externalChecks)")
-
     val settings = Settings(as)
 
     import as.dispatcher

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Settings.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Settings.scala
@@ -39,6 +39,8 @@ final class SettingsImpl(system: ExtendedActorSystem) extends Extension {
       .toMap
   }
 
+  val externalServiceAddressLimit: Int = serviceDiscovery.getInt("external-service-address-limit")
+
   private def duration(config: Config, key: String): FiniteDuration =
     Duration(config.getDuration(key, MILLISECONDS), MILLISECONDS)
 }

--- a/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/javadsl/ServiceLocatorSpec.scala
+++ b/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/javadsl/ServiceLocatorSpec.scala
@@ -18,12 +18,14 @@ package com.lightbend.rp.servicediscovery.javadsl
 
 import akka.actor.ActorSystem
 import akka.testkit.{ ImplicitSender, TestKit }
-import com.lightbend.rp.servicediscovery.scaladsl.Settings
+import com.lightbend.rp.servicediscovery.scaladsl.{ Service, Settings }
 import com.typesafe.config.ConfigFactory
 import java.net.URI
 import java.util.Optional
+
 import org.scalatest.{ AsyncWordSpecLike, BeforeAndAfterAll, Matchers }
-import scala.collection.JavaConversions._
+
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 
 object ServiceLocatorSpec {
@@ -53,24 +55,24 @@ class ServiceLocatorSpec extends TestKit(ActorSystem("service-locator", ServiceL
 
   "addressSelectionFirst" should {
     "work for empty lists" in {
-      ServiceLocator.addressSelectionFirst.select(Seq()) shouldBe Optional.empty[URI]()
+      ServiceLocator.addressSelectionFirst.select(Seq().asJava) shouldBe Optional.empty[URI]()
     }
 
     "work for non-empty lists" in {
       ServiceLocator.addressSelectionFirst.select(
         Seq(
-          new URI("http://127.0.0.1:9000"),
-          new URI("http://127.0.0.1:9001"))).get() shouldBe new URI("http://127.0.0.1:9000")
+          Service("myservice.com", new URI("http://127.0.0.1:9000")),
+          Service("myotherservice.com", new URI("http://127.0.0.1:9001"))).asJava).get() shouldBe Service("myservice.com", new URI("http://127.0.0.1:9000"))
     }
   }
 
   "addressSelectionRandom" should {
     "work for empty lists" in {
-      ServiceLocator.addressSelectionFirst.select(Seq()) shouldBe Optional.empty[URI]()
+      ServiceLocator.addressSelectionFirst.select(Seq().asJava) shouldBe Optional.empty[URI]()
     }
 
     "work for non-empty lists" in {
-      ServiceLocator.addressSelectionFirst.select(Seq(new URI("http://127.0.0.1:9000"))).isPresent shouldBe true
+      ServiceLocator.addressSelectionFirst.select(Seq(Service("hello", new URI("http://127.0.0.1:9000"))).asJava).isPresent shouldBe true
     }
   }
 }

--- a/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
+++ b/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
@@ -65,12 +65,12 @@ class ServiceLocatorSpec extends TestKit(ActorSystem("service-locator", ServiceL
 
     "work for non-empty sequences" in {
       ServiceLocator.AddressSelectionFirst(
-        Seq(new URI("http://127.0.0.1:9000"))).contains(new URI("http://127.0.0.1:9000")) shouldBe true
+        Seq(Service("one", new URI("http://127.0.0.1:9000")))).contains(Service("one", new URI("http://127.0.0.1:9000"))) shouldBe true
 
       ServiceLocator.AddressSelectionFirst(
         Seq(
-          new URI("http://127.0.0.1:9000"),
-          new URI("http://127.0.0.1:9001"))).contains(new URI("http://127.0.0.1:9000")) shouldBe true
+          Service("one1", new URI("http://127.0.0.1:9000")),
+          Service("one2", new URI("http://127.0.0.1:9001")))).contains(Service("one1", new URI("http://127.0.0.1:9000"))) shouldBe true
     }
   }
 
@@ -81,10 +81,10 @@ class ServiceLocatorSpec extends TestKit(ActorSystem("service-locator", ServiceL
 
     "work for non-empty sequences" in {
       ServiceLocator.AddressSelectionRandom(
-        Seq(new URI("http://127.0.0.1:9000"))).contains(new URI("http://127.0.0.1:9000")) shouldBe true
+        Seq(Service("test", new URI("http://127.0.0.1:9000")))).contains(Service("test", new URI("http://127.0.0.1:9000"))) shouldBe true
 
       ServiceLocator.AddressSelectionRandom(
-        Seq(new URI("http://127.0.0.1:9000"), new URI("http://127.0.0.1:9001"))).nonEmpty shouldBe true
+        Seq(Service("test1", new URI("http://127.0.0.1:9000")), Service("test2", new URI("http://127.0.0.1:9001")))).nonEmpty shouldBe true
     }
   }
 
@@ -92,31 +92,34 @@ class ServiceLocatorSpec extends TestKit(ActorSystem("service-locator", ServiceL
     "resolve external services correctly (one)" in {
       ServiceLocator
         .lookup("has-one")
-        .map(_.contains(new URI("http://127.0.0.1:9000")) shouldBe true)
+        .map(_.contains(Service("has-one", new URI("http://127.0.0.1:9000"))) shouldBe true)
     }
 
     "resolve external services correctly (many #1)" in {
       ServiceLocator
         .lookupOne("has-two", "some-endpoint", _.headOption)
-        .map(_.contains(new URI("http://127.0.0.1:8000")) shouldBe true)
+        .map(_.contains(Service("has-two", new URI("http://127.0.0.1:8000"))) shouldBe true)
     }
 
     "resolve external services correctly (many #2)" in {
       ServiceLocator
         .lookupOne("has-two", "some-endpoint", _.lastOption)
-        .map(_.contains(new URI("http://127.0.0.1:8001")) shouldBe true)
+        .map(_.contains(Service("has-two", new URI("http://127.0.0.1:8001"))) shouldBe true)
     }
 
     "recursively resolve (upto a limit) if scheme is missing" in {
       ServiceLocator
         .lookupOne("pointer-one")
-        .map(_.contains(new URI("pointer-four")) shouldBe true)
+        .map(_.contains(Service("pointer-three", new URI("pointer-four"))) shouldBe true)
     }
 
     "recursively resolve name & endpoint" in {
       ServiceLocator
+        .lookupOne("test", "my-lookup", _.headOption).foreach(println)
+
+      ServiceLocator
         .lookupOne("test", "my-lookup", _.headOption)
-        .map(_.contains(new URI("http://127.0.0.1:8000")) shouldBe true)
+        .map(_.contains(Service("has-two", new URI("http://127.0.0.1:8000"))) shouldBe true)
     }
   }
 }


### PR DESCRIPTION
PR does these things:

* Service locator now distinguishes between `lookup` and `lookupOne`.
* Service locator recursively resolves external addresses upto a configured limit
* Socket binding versioning removed
* Socket binding protocol added

It also adds a comment to `build.sbt` as requested in a prior PR to explain the purpose of `assemblyExcludeLocal`.