### PR TITLE
Service Locator now supports lookup using namespace

### DIFF
--- a/service-discovery-lagom13-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
+++ b/service-discovery-lagom13-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
@@ -41,17 +41,7 @@ public class LagomServiceLocator extends CircuitBreakingServiceLocator {
     @Override
     public CompletionStage<Optional<URI>> locate(String name, Descriptor.Call<?, ?> serviceCall) {
         return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator
-                .lookup(name, "lagom-api", actorSystem)
-                .thenApply(new Function<Optional<Service>, Optional<URI>>() {
-                    @Override
-                    public Optional<URI> apply(Optional<Service> service) {
-                        return service.map(new Function<Service, URI>() {
-                            @Override
-                            public URI apply(Service service) {
-                                return service.uri();
-                            }
-                        });
-                    }
-                });
+                .lookupOne(name, "lagom-api", actorSystem)
+                .thenApply(service -> service.map(Service::uri));
     }
 }

--- a/service-discovery-lagom14-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
+++ b/service-discovery-lagom14-java/src/main/java/com/lightbend/rp/servicediscovery/lagom/javadsl/LagomServiceLocator.java
@@ -41,17 +41,7 @@ public class LagomServiceLocator extends CircuitBreakingServiceLocator {
     @Override
     public CompletionStage<Optional<URI>> locate(String name, Descriptor.Call<?, ?> serviceCall) {
         return com.lightbend.rp.servicediscovery.javadsl.ServiceLocator
-                .lookup(name, "lagom-api", actorSystem)
-                .thenApply(new Function<Optional<Service>, Optional<URI>>() {
-                    @Override
-                    public Optional<URI> apply(Optional<Service> service) {
-                        return service.map(new Function<Service, URI>() {
-                            @Override
-                            public URI apply(Service service) {
-                                return service.uri();
-                            }
-                        });
-                    }
-                });
+                .lookupOne(name, "lagom-api", actorSystem)
+                .thenApply(service -> service.map(Service::uri));
     }
 }


### PR DESCRIPTION
The `ServiceLocator` methods are now added to support `namespace` argument.

This means there are multiple `lookup` and `lookupOne` methods which has various numbers of possible argument using `namespace`, `service`, and `endpoint`. This approach is unfortunately necessary as Scala method with default arguments doesn't work with `namespace`, `service`, and `endpoint` being all `String`.

The service locator functionality is now placed in a trait called `ServiceLocatorLike`. This trait is introduced so we can test the internal lookup calls by providing mocked `sys.env` and `akka-dns` `ActorRef`.