### PR TITLE
Read application secret from environment variable

### DIFF
--- a/play-http-binding/src/main/resources/rp-tooling.conf
+++ b/play-http-binding/src/main/resources/rp-tooling.conf
@@ -1,3 +1,9 @@
+# Obtains application secret from RP_PLAY_APPLICATION_SECRET environment variable, falling back to APPLICATION_SECRET
+# as the APPLICATION_SECRET is used in Play documentation, i.e.
+# https://www.playframework.com/documentation/2.6.x/ApplicationSecret#Environment-variables
+play.http.secret.key=${?APPLICATION_SECRET}
+play.http.secret.key=${?RP_PLAY_APPLICATION_SECRET}
+
 play {
   server {
     # See sbt-reactive-app and reactive-cli to understand where these values come from


### PR DESCRIPTION
Read application secret from `RP_PLAY_APPLICATION_SECRET` environment variable, falling back to `APPLICATION_SECRET`.

This is because `APPLICATION_SECRET` is used in Play documentation, i.e.

https://www.playframework.com/documentation/2.6.x/ApplicationSecret#Environment-variables