### PR TITLE
Fix running akka cluster apps locally

### DIFF
--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/ClusterBootstrap.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/ClusterBootstrap.scala
@@ -27,10 +27,8 @@ final class ClusterBootstrap(system: ExtendedActorSystem) extends Extension {
 
   if (cluster.settings.SeedNodes.nonEmpty) {
     system.log.warning("ClusterBootstrap is enabled but seed nodes are defined, no action will be taken")
-  } else if (Platform.active == None) {
-    // When running locally, for example with "sbt runAll", actors join local cluster.
-    cluster.join(cluster.selfAddress)
-    system.log.info("Not starting cluster bootstrap because app is running locally")
+  } else if (Platform.active.isEmpty) {
+    system.log.info("ClusterBootstrap is enabled but no active platform detected (i.e. running locally), no action will be taken")
   } else {
     ClusterHttpManagement(cluster).start()
     Bootstrap(system).start()


### PR DESCRIPTION
Akka cluster applications build with SbtReactiveAppPlugin couldn't be run locally using "sbt runAll". For example https://github.com/longshorej/lagom-java-chirper-tooling-example. It tries to launch an instance for ClusterHttpManagement for each impl project - that fails trying to reuse the same port.

This fix looks up platform which app is running on and doesn't do cluster bootstrapping for local run. It also self-joins the local cluster to allow for actors to communicate.

In the long run, it's probably better to have something like "devmode" switch and execute different logic depending on it. This PR just illustrates minimal changes needed to run things locally.