### PR TITLE
Implement Kubernetes API-based ServiceDiscovery implementation

### DIFF
--- a/akka-cluster-bootstrap/src/main/resources/rp-tooling.conf
+++ b/akka-cluster-bootstrap/src/main/resources/rp-tooling.conf
@@ -24,6 +24,14 @@ akka {
 
       resolve-timeout = 2 second
     }
+
+    reactive-lib-kubernetes {
+      class = com.lightbend.rp.akkaclusterbootstrap.kubernetes.ClusterServiceDiscovery
+
+      resolve-interval = 1 second
+
+      resolve-timeout = 2 second
+    }
   }
 
   extensions += "com.lightbend.rp.akkaclusterbootstrap.ClusterBootstrap"

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/ClusterServiceDiscovery.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/ClusterServiceDiscovery.scala
@@ -28,7 +28,7 @@ class ClusterServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
 
   def lookup(name: String, resolveTimeout: FiniteDuration): Future[Resolved] = {
     ServiceLocator
-      .lookup(name, "akka-mgmt-http")(system)
+      .lookup(name, AkkaManagementPortName)(system)
       .map(services =>
         Resolved(
           name,

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscovery.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscovery.scala
@@ -43,7 +43,8 @@ object ClusterServiceDiscovery {
       item <- podList.items
       container <- item.spec.containers.find(_.name == name)
       port <- container.ports.find(_.name == AkkaManagementPortName)
-    } yield ResolvedTarget(item.status.podIP, Some(port.containerPort))
+      ip <- item.status.podIP
+    } yield ResolvedTarget(ip, Some(port.containerPort))
 }
 
 /**

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscovery.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscovery.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.akkaclusterbootstrap.kubernetes
+
+import akka.actor.ActorSystem
+import akka.discovery.ServiceDiscovery
+import akka.http.scaladsl._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.FileIO
+import com.lightbend.rp.akkaclusterbootstrap.AkkaManagementPortName
+import com.lightbend.rp.common._
+import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import com.typesafe.sslconfig.ssl.TrustStoreConfig
+import java.nio.file.Paths
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Try
+
+import JsonFormat._
+import ServiceDiscovery._
+
+object ClusterServiceDiscovery {
+  private[kubernetes] def targets(podList: PodList, name: String): Seq[ResolvedTarget] =
+    for {
+      item <- podList.items
+      container <- item.spec.containers.find(_.name == name)
+      port <- container.ports.find(_.name == AkkaManagementPortName)
+    } yield ResolvedTarget(item.status.podIP, Some(port.containerPort))
+}
+
+/**
+ * An alternative implementation that uses the Kubernetes API. Currently,
+ * reactive-cli specifies this via arguments when it generates resources
+ * for Kubernets targets. Thus, the default implementation for reactive-lib
+ * remains one based on the service locator.
+ *
+ * The main advantage of this is that we can discover pods that aren't yet ready,
+ * perhaps they have health checks that rely on Akka Cluster being up.
+ */
+class ClusterServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
+  import ClusterServiceDiscovery._
+  import system.dispatcher
+
+  private val http = Http()(system)
+
+  private implicit val mat: ActorMaterializer = ActorMaterializer()(system)
+
+  private val sslConfig =
+    AkkaSSLConfig()(system)
+      .mapSettings(s =>
+        s.withTrustManagerConfig(
+          s.trustManagerConfig
+            .withTrustStoreConfigs(
+              Seq(
+                TrustStoreConfig(data = None, filePath = Some(KubernetesCAPath))
+                  .withStoreType("PEM")))))
+
+  private val sslContext = http.createClientHttpsContext(sslConfig)
+
+  def lookup(name: String, resolveTimeout: FiniteDuration): Future[Resolved] =
+    for {
+      token <- apiToken()
+
+      request <- optionToFuture(
+        podRequest(token, Namespace.active.getOrElse(kubernetes.DefaultNamespace), name),
+        "Unable to form request; check Kubernetes environment")
+
+      response <- http.singleRequest(request, sslContext)
+
+      entity <- response.entity.toStrict(resolveTimeout)
+
+      podList <- Unmarshal(entity).to[PodList]
+
+    } yield Resolved(name, targets(podList, name))
+
+  private def apiToken() =
+    FileIO.fromPath(Paths.get(KubernetesToken))
+      .runFold("")(_ + _.utf8String)
+      .recover { case _: Throwable => "" }
+
+  private def optionToFuture[T](option: Option[T], failMsg: String): Future[T] =
+    option.fold(Future.failed[T](new NoSuchElementException(failMsg)))(Future.successful)
+
+  private def podRequest(token: String, namespace: String, name: String) = {
+    for {
+      platform <- Platform.active
+
+      if platform == Kubernetes
+
+      host <- sys.env.get("KUBERNETES_SERVICE_HOST")
+      portStr <- sys.env.get("KUBERNETES_SERVICE_PORT")
+      port <- Try(portStr.toInt).toOption
+    } yield {
+      val path = Uri.Path.Empty / "api" / "v1" / "namespaces" / namespace / "pods"
+      val query = Uri.Query("labelSelector" -> s"appName=$name")
+      val uri = Uri.from(scheme = "https", host = host, port = port)
+        .withPath(path)
+        .withQuery(query)
+
+      HttpRequest(uri = uri, headers = Seq(Authorization(OAuth2BearerToken(token))))
+    }
+  }
+}

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/JsonFormat.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/JsonFormat.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.akkaclusterbootstrap.kubernetes
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json._
+
+import PodList._
+
+object JsonFormat extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val portFormat: JsonFormat[Port] = jsonFormat2(Port)
+  implicit val containerFormat: JsonFormat[Container] = jsonFormat2(Container)
+  implicit val specFormat: JsonFormat[Spec] = jsonFormat1(Spec)
+  implicit val statusFormat: JsonFormat[Status] = jsonFormat1(Status)
+  implicit val itemFormat: JsonFormat[Item] = jsonFormat2(Item)
+  implicit val podListFormat: RootJsonFormat[PodList] = jsonFormat1(PodList.apply)
+}

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/PodList.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/PodList.scala
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.common
+package com.lightbend.rp.akkaclusterbootstrap.kubernetes
 
-sealed trait Platform
+import scala.collection.immutable.Seq
 
-case object Kubernetes extends Platform
-
-object Platform {
-  lazy val active: Option[Platform] = decode(sys.env.get("RP_PLATFORM"))
-
-  private[rp] def decode(platform: Option[String]) = platform match {
-    case Some("kubernetes") => Some(Kubernetes)
-    case _ => None
-  }
+object PodList {
+  case class Port(name: String, containerPort: Int)
+  case class Container(name: String, ports: Seq[Port])
+  case class Spec(containers: Seq[Container])
+  case class Status(podIP: String)
+  case class Item(spec: Spec, status: Status)
 }
+
+import PodList._
+
+case class PodList(items: Seq[Item])

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/PodList.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/PodList.scala
@@ -22,7 +22,7 @@ object PodList {
   case class Port(name: String, containerPort: Int)
   case class Container(name: String, ports: Seq[Port])
   case class Spec(containers: Seq[Container])
-  case class Status(podIP: String)
+  case class Status(podIP: Option[String])
   case class Item(spec: Spec, status: Status)
 }
 

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/package.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/package.scala
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.common
+package com.lightbend.rp.akkaclusterbootstrap
 
-sealed trait Platform
-
-case object Kubernetes extends Platform
-
-object Platform {
-  lazy val active: Option[Platform] = decode(sys.env.get("RP_PLATFORM"))
-
-  private[rp] def decode(platform: Option[String]) = platform match {
-    case Some("kubernetes") => Some(Kubernetes)
-    case _ => None
-  }
+package object kubernetes {
+  val KubernetesCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+  val KubernetesToken = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }

--- a/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/package.scala
+++ b/akka-cluster-bootstrap/src/main/scala/com/lightbend/rp/akkaclusterbootstrap/package.scala
@@ -14,17 +14,8 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.common
+package com.lightbend.rp
 
-sealed trait Platform
-
-case object Kubernetes extends Platform
-
-object Platform {
-  lazy val active: Option[Platform] = decode(sys.env.get("RP_PLATFORM"))
-
-  private[rp] def decode(platform: Option[String]) = platform match {
-    case Some("kubernetes") => Some(Kubernetes)
-    case _ => None
-  }
+package object akkaclusterbootstrap {
+  val AkkaManagementPortName = "akka-mgmt-http"
 }

--- a/akka-cluster-bootstrap/src/test/resources/pods.json
+++ b/akka-cluster-bootstrap/src/test/resources/pods.json
@@ -1,0 +1,1057 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/pods",
+    "resourceVersion": "16042"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-dvm9q",
+        "generateName": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/akka-cluster-tooling-example-v0-1-0-7f854bcc78-dvm9q",
+        "uid": "5fe7a41b-da9a-11e7-b064-0800270d668b",
+        "resourceVersion": "6523",
+        "creationTimestamp": "2017-12-06T15:30:22Z",
+        "labels": {
+          "appName": "akka-cluster-tooling-example",
+          "appNameVersion": "akka-cluster-tooling-example-v0-1-0",
+          "pod-template-hash": "3941067734"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"akka-cluster-tooling-example-v0-1-0-7f854bcc78\",\"uid\":\"5fdc6a1c-da9a-11e7-b064-0800270d668b\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"3173\"}}\n"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "ReplicaSet",
+            "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78",
+            "uid": "5fdc6a1c-da9a-11e7-b064-0800270d668b",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-zkgn4",
+            "secret": {
+              "secretName": "default-token-zkgn4",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "ports": [
+              {
+                "name": "akka-remote",
+                "containerPort": 10000,
+                "protocol": "TCP"
+              },
+              {
+                "name": "akka-mgmt-http",
+                "containerPort": 10001,
+                "protocol": "TCP"
+              },
+              {
+                "name": "http",
+                "containerPort": 10002,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "JAVA_OPTS",
+                "value": "-Drp.service-discovery.ask-timeout=1ms"
+              },
+              {
+                "name": "RP_APP_NAME",
+                "value": "akka-cluster-tooling-example"
+              },
+              {
+                "name": "RP_APP_TYPE",
+                "value": "basic"
+              },
+              {
+                "name": "RP_APP_VERSION",
+                "value": "0.1.0"
+              },
+              {
+                "name": "RP_ENDPOINTS",
+                "value": "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
+              },
+              {
+                "name": "RP_ENDPOINTS_COUNT",
+                "value": "3"
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_0_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_1_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_2_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_JAVA_OPTS",
+                "value": "-Dconfig.resource=rp-application.conf -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3"
+              },
+              {
+                "name": "RP_KUBERNETES_POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_KUBERNETES_POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "RP_MODULES",
+                "value": "akka-cluster-bootstrapping,common,service-discovery"
+              },
+              {
+                "name": "RP_PLATFORM",
+                "value": "kubernetes"
+              }
+            ],
+            "resources": {
+
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-zkgn4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T17:36:57Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          }
+        ],
+        "hostIP": "192.168.99.109",
+        "podIP": "172.17.0.4",
+        "startTime": "2017-12-06T15:30:22Z",
+        "containerStatuses": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "state": {
+              "running": {
+                "startedAt": "2017-12-06T17:36:57Z"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 137,
+                "reason": "Error",
+                "startedAt": "2017-12-06T15:30:24Z",
+                "finishedAt": "2017-12-06T17:36:50Z",
+                "containerID": "docker://294b22a68ac2d91f64586ad349f5c4012bce5e3d0a51197ee21451b7eada0617"
+              }
+            },
+            "ready": true,
+            "restartCount": 1,
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "imageID": "docker://sha256:db3827171cfd7cea96f35e75e9df30e198f25b66a8e75e8167b09ad9e1a18c10",
+            "containerID": "docker://d805076f4737166117229aaa4eaf5e7eb974da0b4c781b2f6ec126d5046a4c3f"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    },
+    {
+      "metadata": {
+        "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-m8dqb",
+        "generateName": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/akka-cluster-tooling-example-v0-1-0-7f854bcc78-m8dqb",
+        "uid": "5fe22476-da9a-11e7-b064-0800270d668b",
+        "resourceVersion": "6520",
+        "creationTimestamp": "2017-12-06T15:30:22Z",
+        "labels": {
+          "appNameVersion": "akka-cluster-tooling-example-v0-1-0",
+          "pod-template-hash": "3941067734",
+          "appName": "akka-cluster-tooling-example"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"akka-cluster-tooling-example-v0-1-0-7f854bcc78\",\"uid\":\"5fdc6a1c-da9a-11e7-b064-0800270d668b\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"3173\"}}\n"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "ReplicaSet",
+            "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78",
+            "uid": "5fdc6a1c-da9a-11e7-b064-0800270d668b",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-zkgn4",
+            "secret": {
+              "secretName": "default-token-zkgn4",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "ports": [
+              {
+                "name": "akka-remote",
+                "containerPort": 10000,
+                "protocol": "TCP"
+              },
+              {
+                "name": "akka-mgmt-http",
+                "containerPort": 10001,
+                "protocol": "TCP"
+              },
+              {
+                "name": "http",
+                "containerPort": 10002,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "JAVA_OPTS",
+                "value": "-Drp.service-discovery.ask-timeout=1ms"
+              },
+              {
+                "name": "RP_APP_NAME",
+                "value": "akka-cluster-tooling-example"
+              },
+              {
+                "name": "RP_APP_TYPE",
+                "value": "basic"
+              },
+              {
+                "name": "RP_APP_VERSION",
+                "value": "0.1.0"
+              },
+              {
+                "name": "RP_ENDPOINTS",
+                "value": "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
+              },
+              {
+                "name": "RP_ENDPOINTS_COUNT",
+                "value": "3"
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_0_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_1_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_2_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_JAVA_OPTS",
+                "value": "-Dconfig.resource=rp-application.conf -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3"
+              },
+              {
+                "name": "RP_KUBERNETES_POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_KUBERNETES_POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "RP_MODULES",
+                "value": "akka-cluster-bootstrapping,common,service-discovery"
+              },
+              {
+                "name": "RP_PLATFORM",
+                "value": "kubernetes"
+              }
+            ],
+            "resources": {
+
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-zkgn4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T17:36:57Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          }
+        ],
+        "hostIP": "192.168.99.109",
+        "podIP": "172.17.0.6",
+        "startTime": "2017-12-06T15:30:22Z",
+        "containerStatuses": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "state": {
+              "running": {
+                "startedAt": "2017-12-06T17:36:57Z"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 137,
+                "reason": "Error",
+                "startedAt": "2017-12-06T15:30:24Z",
+                "finishedAt": "2017-12-06T17:36:50Z",
+                "containerID": "docker://b5880747113029524ba902c561df5637f45b73a225bab52e8ed0395588432101"
+              }
+            },
+            "ready": true,
+            "restartCount": 1,
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "imageID": "docker://sha256:db3827171cfd7cea96f35e75e9df30e198f25b66a8e75e8167b09ad9e1a18c10",
+            "containerID": "docker://ba80f96ce994517bc2d49d2930923c54b818bdd3a1aa8e60e42944e8ac4bf730"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    },
+    {
+      "metadata": {
+        "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-xncvj",
+        "generateName": "akka-cluster-tooling-example-v0-1-0-7f854bcc78-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/akka-cluster-tooling-example-v0-1-0-7f854bcc78-xncvj",
+        "uid": "5fe6b0c7-da9a-11e7-b064-0800270d668b",
+        "resourceVersion": "6593",
+        "creationTimestamp": "2017-12-06T15:30:22Z",
+        "labels": {
+          "pod-template-hash": "3941067734",
+          "appName": "akka-cluster-tooling-example",
+          "appNameVersion": "akka-cluster-tooling-example-v0-1-0"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"akka-cluster-tooling-example-v0-1-0-7f854bcc78\",\"uid\":\"5fdc6a1c-da9a-11e7-b064-0800270d668b\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"3173\"}}\n"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "ReplicaSet",
+            "name": "akka-cluster-tooling-example-v0-1-0-7f854bcc78",
+            "uid": "5fdc6a1c-da9a-11e7-b064-0800270d668b",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-zkgn4",
+            "secret": {
+              "secretName": "default-token-zkgn4",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "ports": [
+              {
+                "name": "akka-remote",
+                "containerPort": 10000,
+                "protocol": "TCP"
+              },
+              {
+                "name": "akka-mgmt-http",
+                "containerPort": 10001,
+                "protocol": "TCP"
+              },
+              {
+                "name": "http",
+                "containerPort": 10002,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "JAVA_OPTS",
+                "value": "-Drp.service-discovery.ask-timeout=1ms"
+              },
+              {
+                "name": "RP_APP_NAME",
+                "value": "akka-cluster-tooling-example"
+              },
+              {
+                "name": "RP_APP_TYPE",
+                "value": "basic"
+              },
+              {
+                "name": "RP_APP_VERSION",
+                "value": "0.1.0"
+              },
+              {
+                "name": "RP_ENDPOINTS",
+                "value": "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
+              },
+              {
+                "name": "RP_ENDPOINTS_COUNT",
+                "value": "3"
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_0_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_0_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_1_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_1_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_2_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_2_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT",
+                "value": "10001"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_AKKA_REMOTE_PORT",
+                "value": "10000"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_BIND_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_HOST",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_ENDPOINT_HTTP_PORT",
+                "value": "10002"
+              },
+              {
+                "name": "RP_JAVA_OPTS",
+                "value": "-Dconfig.resource=rp-application.conf -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3"
+              },
+              {
+                "name": "RP_KUBERNETES_POD_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.podIP"
+                  }
+                }
+              },
+              {
+                "name": "RP_KUBERNETES_POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "RP_MODULES",
+                "value": "akka-cluster-bootstrapping,common,service-discovery"
+              },
+              {
+                "name": "RP_PLATFORM",
+                "value": "kubernetes"
+              }
+            ],
+            "resources": {
+
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-zkgn4",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "minikube",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T17:37:17Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-12-06T15:30:22Z"
+          }
+        ],
+        "hostIP": "192.168.99.109",
+        "podIP": "172.17.0.7",
+        "startTime": "2017-12-06T15:30:22Z",
+        "containerStatuses": [
+          {
+            "name": "akka-cluster-tooling-example",
+            "state": {
+              "running": {
+                "startedAt": "2017-12-06T17:37:16Z"
+              }
+            },
+            "lastState": {
+              "terminated": {
+                "exitCode": 137,
+                "reason": "Error",
+                "startedAt": "2017-12-06T15:30:24Z",
+                "finishedAt": "2017-12-06T17:36:50Z",
+                "containerID": "docker://c516ab6640a1a67d6f24337025930812ec73f08a1ba1ae2a3533c6645a751d31"
+              }
+            },
+            "ready": true,
+            "restartCount": 1,
+            "image": "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
+            "imageID": "docker://sha256:db3827171cfd7cea96f35e75e9df30e198f25b66a8e75e8167b09ad9e1a18c10",
+            "containerID": "docker://075e85c889ffd715849f8d683702623790c44f93beeea5711a63a8b6ef9e5272"
+          }
+        ],
+        "qosClass": "BestEffort"
+      }
+    }
+  ]
+}

--- a/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscoverySpec.scala
+++ b/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscoverySpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.akkaclusterbootstrap.kubernetes
+
+import org.scalatest.{ Matchers, WordSpec }
+import PodList._
+import akka.discovery.ServiceDiscovery.ResolvedTarget
+
+class ClusterServiceDiscoverySpec extends WordSpec with Matchers {
+  "targets" should {
+    "calculate the correct list of resolved targets" in {
+      val podList = PodList(
+        List(
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status("172.17.0.4")),
+
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-other-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status("172.17.0.6")),
+
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-another-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status("172.17.0.7"))))
+
+      ClusterServiceDiscovery.targets(podList, "akka-cluster-tooling-example") shouldBe List(
+        ResolvedTarget("172.17.0.4", Some(10001)))
+    }
+  }
+}

--- a/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscoverySpec.scala
+++ b/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/ClusterServiceDiscoverySpec.scala
@@ -31,7 +31,15 @@ class ClusterServiceDiscoverySpec extends WordSpec with Matchers {
                 Container(
                   "akka-cluster-tooling-example",
                   List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status("172.17.0.4")),
+            Status(Some("172.17.0.4"))),
+
+          Item(
+            Spec(
+              List(
+                Container(
+                  "akka-cluster-tooling-example",
+                  List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+            Status(None)),
 
           Item(
             Spec(
@@ -39,7 +47,7 @@ class ClusterServiceDiscoverySpec extends WordSpec with Matchers {
                 Container(
                   "akka-cluster-tooling-other-example",
                   List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status("172.17.0.6")),
+            Status(Some("172.17.0.6"))),
 
           Item(
             Spec(
@@ -47,7 +55,7 @@ class ClusterServiceDiscoverySpec extends WordSpec with Matchers {
                 Container(
                   "akka-cluster-tooling-another-example",
                   List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-            Status("172.17.0.7"))))
+            Status(Some("172.17.0.7")))))
 
       ClusterServiceDiscovery.targets(podList, "akka-cluster-tooling-example") shouldBe List(
         ResolvedTarget("172.17.0.4", Some(10001)))

--- a/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/JsonFormatSpec.scala
+++ b/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/JsonFormatSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.akkaclusterbootstrap.kubernetes
+
+import org.scalatest.{ Matchers, WordSpec }
+import scala.io.Source
+import spray.json._
+
+import PodList._
+
+class JsonFormatSpec extends WordSpec with Matchers {
+  "JsonFormat" should {
+    val data = resourceAsString("pods.json")
+
+    "work" in {
+      JsonFormat
+        .podListFormat
+        .read(data.parseJson) shouldBe PodList(
+          List(
+            Item(
+              Spec(
+                List(
+                  Container(
+                    "akka-cluster-tooling-example",
+                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+              Status("172.17.0.4")),
+
+            Item(
+              Spec(
+                List(
+                  Container(
+                    "akka-cluster-tooling-example",
+                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+              Status("172.17.0.6")),
+
+            Item(
+              Spec(
+                List(
+                  Container(
+                    "akka-cluster-tooling-example",
+                    List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
+              Status("172.17.0.7"))))
+    }
+  }
+
+  private def resourceAsString(name: String): String =
+    Source
+      .fromInputStream(getClass.getClassLoader.getResourceAsStream(name))
+      .mkString
+}

--- a/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/JsonFormatSpec.scala
+++ b/akka-cluster-bootstrap/src/test/scala/com/lightbend/rp/akkaclusterbootstrap/kubernetes/JsonFormatSpec.scala
@@ -37,7 +37,7 @@ class JsonFormatSpec extends WordSpec with Matchers {
                   Container(
                     "akka-cluster-tooling-example",
                     List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-              Status("172.17.0.4")),
+              Status(Some("172.17.0.4"))),
 
             Item(
               Spec(
@@ -45,7 +45,7 @@ class JsonFormatSpec extends WordSpec with Matchers {
                   Container(
                     "akka-cluster-tooling-example",
                     List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-              Status("172.17.0.6")),
+              Status(Some("172.17.0.6"))),
 
             Item(
               Spec(
@@ -53,7 +53,7 @@ class JsonFormatSpec extends WordSpec with Matchers {
                   Container(
                     "akka-cluster-tooling-example",
                     List(Port("akka-remote", 10000), Port("akka-mgmt-http", 10001), Port("http", 10002))))),
-              Status("172.17.0.7"))))
+              Status(Some("172.17.0.7")))))
     }
   }
 

--- a/common/src/main/scala/com/lightbend/rp/common/Namespace.scala
+++ b/common/src/main/scala/com/lightbend/rp/common/Namespace.scala
@@ -16,15 +16,6 @@
 
 package com.lightbend.rp.common
 
-sealed trait Platform
-
-case object Kubernetes extends Platform
-
-object Platform {
-  lazy val active: Option[Platform] = decode(sys.env.get("RP_PLATFORM"))
-
-  private[rp] def decode(platform: Option[String]) = platform match {
-    case Some("kubernetes") => Some(Kubernetes)
-    case _ => None
-  }
+object Namespace {
+  lazy val active: Option[String] = sys.env.get("RP_NAMESPACE")
 }

--- a/common/src/main/scala/com/lightbend/rp/common/kubernetes/package.scala
+++ b/common/src/main/scala/com/lightbend/rp/common/kubernetes/package.scala
@@ -16,15 +16,6 @@
 
 package com.lightbend.rp.common
 
-sealed trait Platform
-
-case object Kubernetes extends Platform
-
-object Platform {
-  lazy val active: Option[Platform] = decode(sys.env.get("RP_PLATFORM"))
-
-  private[rp] def decode(platform: Option[String]) = platform match {
-    case Some("kubernetes") => Some(Kubernetes)
-    case _ => None
-  }
+package object kubernetes {
+  val DefaultNamespace: String = "default"
 }

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
@@ -95,7 +95,7 @@ trait ServiceLocatorLike {
         if (name.exists(DnsCharacters.contains) && endpoint.isEmpty) {
           name
         } else {
-          val serviceNamespace = namespace.orElse(namespaceFromEnv()).getOrElse("default")
+          val serviceNamespace = namespace.orElse(namespaceFromEnv()).getOrElse(kubernetes.DefaultNamespace)
           val serviceName = endpointServiceName(name)
           val endpointName = endpointServiceName(endpoint)
 


### PR DESCRIPTION
This PR uses the Kubernetes API instead of the service locator (based on DNS SRV) to discover other pods.

The CLI will add configuration when it generates the resources to select this implementation for Kubernetes environments.