### PR TITLE
SecretReader can read from files (location via convention)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -225,5 +225,9 @@ lazy val playHttpBinding = createProject("reactive-lib-play-http-binding", "play
 lazy val secrets = createProject("reactive-lib-secrets", "secrets")
   .dependsOn(common)
   .settings(
-    crossScalaVersions := Vector(Versions.scala211, Versions.scala212)
+    crossScalaVersions := Vector(Versions.scala211, Versions.scala212),
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-actor"  % Versions.akka % "provided",
+      "com.typesafe.akka" %% "akka-stream" % Versions.akka % "provided"
+    )
   )

--- a/secrets/src/main/java/com/lightbend/rp/secrets/javadsl/SecretReader.java
+++ b/secrets/src/main/java/com/lightbend/rp/secrets/javadsl/SecretReader.java
@@ -16,15 +16,21 @@
 
 package com.lightbend.rp.secrets.javadsl;
 
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.util.ByteString;
 import com.lightbend.rp.secrets.scaladsl.SecretReader$;
-import scala.Option;
-
 import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import scala.compat.java8.FutureConverters;
+import scala.compat.java8.OptionConverters;
 
 public class SecretReader {
-    public static Optional<String> get(String namespace, String name) {
-        Option<String> secret = SecretReader$.MODULE$.apply(namespace, name);
-
-        return secret.isDefined() ? Optional.of(secret.get()) : Optional.empty();
+    public static CompletionStage<Optional<ByteString>> get(String name, String key, ActorSystem actorSystem, ActorMaterializer mat) {
+        return FutureConverters.toJava(
+                SecretReader$
+                        .MODULE$
+                        .get(name, key, actorSystem, mat)
+        ).thenApply(OptionConverters::toJava);
     }
 }

--- a/secrets/src/test/scala/com/lightbend/rp/secrets/scaladsl/SecretReaderSpec.scala
+++ b/secrets/src/test/scala/com/lightbend/rp/secrets/scaladsl/SecretReaderSpec.scala
@@ -25,4 +25,10 @@ class SecretReaderSpec extends WordSpec with Matchers {
       SecretReader.envName("test3!!", "hello  there") shouldBe "RP_SECRETS_TEST3___HELLO__THERE"
     }
   }
+
+  "filePath" should {
+    "work" in {
+      SecretReader.filePath("my-secret", "my-key").toString shouldBe "/rp/secrets/my-secret/my-key"
+    }
+  }
 }


### PR DESCRIPTION
`SecretReader` returns `Future[ByteString]` to support arbitrary binary data.

`Secret` now defined as a `name` and a `key` instead of a `namespace` and `name` which was easy to confuse with other concepts of namespace.

If environment variable for a secret lookup doesn't yield anything, it will now check hard-coded path given secret name and key.

This is accompanied by changes in the CLI to populate secrets to files instead of environment variables.