### PR TITLE
Provide LagomServiceLocatorComponent trait

### DIFF
--- a/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocatorComponents.scala
+++ b/service-discovery-lagom13-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocatorComponents.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.servicediscovery.lagom.scaladsl
+
+import com.lightbend.lagom.scaladsl.api.ServiceLocator
+import com.lightbend.lagom.scaladsl.client.CircuitBreakerComponents
+
+trait LagomServiceLocatorComponents extends CircuitBreakerComponents {
+  lazy val serviceLocator: ServiceLocator = new LagomServiceLocator(circuitBreakers)(actorSystem, executionContext)
+}

--- a/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocatorComponents.scala
+++ b/service-discovery-lagom14-scala/src/main/scala/com/lightbend/rp/servicediscovery/lagom/scaladsl/LagomServiceLocatorComponents.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.servicediscovery.lagom.scaladsl
+
+import com.lightbend.lagom.scaladsl.api.ServiceLocator
+import com.lightbend.lagom.scaladsl.client.CircuitBreakerComponents
+
+trait LagomServiceLocatorComponents extends CircuitBreakerComponents {
+  lazy val serviceLocator: ServiceLocator = new LagomServiceLocator(circuitBreakersPanel)(actorSystem, executionContext)
+}


### PR DESCRIPTION
This will allow user to mix this trait to obtain reference to Reactive Lib's LagomServiceLocator when creating application loader to be used within Lagom Scala.