### PR TITLE
Temporarily Reinstate Akka DNS as normal dependency

### DIFF
--- a/service-discovery/src/main/resources/rp-tooling.conf
+++ b/service-discovery/src/main/resources/rp-tooling.conf
@@ -6,8 +6,10 @@ akka {
     dns {
       resolver = async-dns
       async-dns {
+        # FIXME: temporarily disable this until we sort out the issue around shaded Akka DNS dependency
         # This has to be set to the name of the shaded class
-        provider-object = "com.lightbend.rp.internal.ru.smslv.akka.dns.AsyncDnsProvider"
+        # provider-object = "com.lightbend.rp.internal.ru.smslv.akka.dns.AsyncDnsProvider"
+        provider-object = "ru.smslv.akka.dns.AsyncDnsProvider"
         resolve-srv = true
         resolv-conf = on
       }


### PR DESCRIPTION
This is done to mitigate the fact that tooling has been released with the following problem.

If a non-Lagom project enables a service locator, the shaded Reactive Lib will fail with the following error.

```
[error] missing or invalid dependency detected while loading class file 'ServiceLocatorLike.class'.
[error] Could not access term ru in package <root>,
[error] because it (or its dependencies) are missing. Check your build definition for
[error] missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
[error] A full rebuild may help if 'ServiceLocatorLike.class' was compiled against an incompatible version of <root>.
```

This revert is done so the tooling that's released will at least work with Akka DNS as dependency while we are working to ensure the issue above does not occur with Akka DNS shading.