### PR TITLE
WIP - DON'T MERGE - Reinstate shading for akka dns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -245,8 +245,11 @@ lazy val temporaryDependenciesSettings = Vector(
   ))
 
 lazy val serviceDiscovery = createProject("reactive-lib-service-discovery", "service-discovery")
-  .dependsOn(common, shadedAkkaDns)
+  .dependsOn(common)
   .settings(
+    unmanagedJars in Compile ++= Seq(
+      (assembly in Compile in shadedAkkaDns).value
+    ),
     libraryDependencies ++= Seq(
       "com.typesafe.akka"        %% "akka-actor"          % Versions.akka    % "provided",
       "com.typesafe.akka"        %% "akka-testkit"        % Versions.akka    % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -172,6 +172,7 @@ lazy val shadedAkkaDns = Project(id = "shaded-akka-dns", base = file("shaded-akk
     target in assembly := {
       baseDirectory.value / "target" / scalaVersionMajor.value
     },
+    packageBin in Compile := (assembly in Compile).value,
     addArtifact(Artifact("shaded-akka-dns", "assembly"), sbtassembly.AssemblyKeys.assembly),
     assemblyShadeRules in assembly := Seq(
       ShadeRule.rename("akka.io.AsyncDnsResolver**" -> "com.lightbend.rp.internal.@0").inAll,

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
@@ -17,7 +17,7 @@
 package com.lightbend.rp.servicediscovery.scaladsl
 
 import akka.actor._
-import akka.io.AsyncDnsResolver.SrvResolved
+import com.lightbend.rp.internal.akka.io.AsyncDnsResolver.SrvResolved
 import akka.io.Dns.Resolved
 import akka.io.{ Dns, IO }
 import akka.pattern.ask
@@ -26,7 +26,7 @@ import com.lightbend.rp.servicediscovery.scaladsl.ServiceLocatorLike.{ AddressSe
 import java.net.URI
 import java.util.concurrent.ThreadLocalRandom
 
-import ru.smslv.akka.dns.raw.SRVRecord
+import com.lightbend.rp.internal.ru.smslv.akka.dns.raw.SRVRecord
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future


### PR DESCRIPTION
Issues
* [x] The `reference.conf` inside Akka DNS won't be shaded, we need to text replace `ru.` package ourselves.
* [ ] Akka DNS is not excluded from Ivy deps.
* [ ] Compile failure in `ServiceLocator` project. Something is still referencing `ru` package from the `root` package.