### PR TITLE
Import akka-dns as async-dns subproject, removing need for custom resolver or shading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # reactive-lib
 
+An application library that is a component of [Lightbend Platform Tooling](https://s3-us-west-2.amazonaws.com/rp-tooling-temp-docs/home.html),
+a project aimed at making it easier to deploy to orchestrated environments like Kubernetes.
+
 ## Maintenance
 
 Enterprise Suite Platform Team <es-platform@lightbend.com>
 
+## Third-party License
+
+This project includes a copy of [akka-dns](https://github.com/ilya-epifanov/akka-dns), Copyright 2014-2016 Ilya Epifanov.
+Refer to the `async-dns` directory for more information.
+
 ## License
 
-Copyright (C) 2017 Lightbend Inc. (https://www.lightbend.com).
+Copyright (C) 2017-2018 Lightbend Inc. (https://www.lightbend.com).
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 

--- a/async-dns/LICENSE
+++ b/async-dns/LICENSE
@@ -1,0 +1,190 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2014-2016 Ilya Epifanov
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/async-dns/README.md
+++ b/async-dns/README.md
@@ -1,0 +1,3 @@
+# async-dns
+
+This subproject is a fork of [akka-dns](https://github.com/ilya-epifanov/akka-dns), Copyright 2014-2016 Ilya Epifanov

--- a/async-dns/src/main/resources/reference.conf
+++ b/async-dns/src/main/resources/reference.conf
@@ -1,0 +1,45 @@
+akka {
+  actor {
+    deployment {
+      /IO-DNS/async-dns {
+        mailbox = "unbounded"
+        router = "round-robin-pool"
+        nr-of-instances = 1
+      }
+    }
+  }
+  io {
+    dns {
+      async-dns {
+        provider-object = "com.lightbend.rp.asyncdns.AsyncDnsProvider"
+
+        min-positive-ttl = 0s
+        max-positive-ttl = 1d
+        negative-ttl = 10s
+
+        resolve-ipv4 = true
+        resolve-ipv6 = true
+        resolve-srv  = false
+
+        # How often to sweep out expired cache entries.
+        # Note that this interval has nothing to do with TTLs
+        cache-cleanup-interval = 120s
+
+        # The IPs of nameservers to use e.g.
+        # akka.io.dns.async-dns {
+        #   nameservers = ["8.8.8.8", "8.8.4.4"]
+        # }
+        nameservers = []
+
+        # Whether to use the system's /etc/resolv.conf in place
+        # of nameservers
+        resolv-conf = off
+
+        # The time that a request is allowed to live before being discarded
+        # given no reply. The lower bound of this should always be the amount
+        # of time to reasonably expect a DNS server to reply within.
+        request-ttl = 5s
+      }
+    }
+  }
+}

--- a/async-dns/src/main/scala/akka/io/RichSimpleDnsCache.scala
+++ b/async-dns/src/main/scala/akka/io/RichSimpleDnsCache.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2018 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package akka.io
+
+import scala.language.implicitConversions
+
+object RichSimpleDnsCache {
+  implicit def enrichedSimpleDnsCache(c: SimpleDnsCache): RichSimpleDnsCache =
+    new RichSimpleDnsCache(c)
+}
+
+/**
+ * This class exists to expose `private[io] def put(...)` to AsyncDnsResolver.
+ */
+final class RichSimpleDnsCache(val underlying: SimpleDnsCache) extends AnyVal {
+  def doPut(r: Dns.Resolved, ttlMillis: Long): Unit = underlying.put(r, ttlMillis)
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/AsyncDnsProvider.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/AsyncDnsProvider.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns
+
+import akka.io.{ Dns, DnsProvider, SimpleDnsCache, SimpleDnsManager }
+
+final class AsyncDnsProvider extends DnsProvider {
+  override def cache: Dns = new SimpleDnsCache()
+
+  override def actorClass = classOf[AsyncDnsResolver]
+
+  override def managerClass = classOf[SimpleDnsManager]
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/AsyncDnsResolver.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/AsyncDnsResolver.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns
+
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
+import akka.io._
+import com.typesafe.config.Config
+import com.lightbend.rp.asyncdns.raw.{ AAAARecord, ARecord, Answer, CNAMERecord, DnsClient, Question4, Question6, SRVRecord, SrvQuestion }
+import java.io.File
+import java.net.{ Inet4Address, Inet6Address, InetAddress, InetSocketAddress }
+import java.nio.file.Paths
+import java.util.concurrent.{ ThreadLocalRandom, TimeUnit }
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.{ breakOut, immutable }
+import scala.concurrent.duration.{ Deadline, FiniteDuration }
+import scala.io.Source
+import scala.util.control.NonFatal
+
+import RichSimpleDnsCache._
+
+class AsyncDnsResolver(cache: SimpleDnsCache, config: Config) extends Actor with ActorLogging {
+
+  import AsyncDnsResolver._
+
+  private val systemNameServers =
+    if (config.getBoolean("resolv-conf"))
+      parseSystemNameServers(Paths.get("/etc/resolv.conf").toFile)
+    else
+      Option.empty[immutable.Seq[InetSocketAddress]]
+  private val nameServers: immutable.Seq[InetSocketAddress] =
+    systemNameServers.getOrElse(config.getStringList("nameservers").asScala.map(parseNameserverAddress)(breakOut))
+  private val resolveIpv4 = config.getBoolean("resolve-ipv4")
+  private val resolveIpv6 = config.getBoolean("resolve-ipv6")
+  private val resolveSrv = config.getBoolean("resolve-srv")
+  private val negativeTtl = config.getDuration("negative-ttl", TimeUnit.MILLISECONDS)
+  private val minPositiveTtl = config.getDuration("max-positive-ttl", TimeUnit.MILLISECONDS)
+  private val maxPositiveTtl = config.getDuration("max-positive-ttl", TimeUnit.MILLISECONDS)
+  private val requestTtl = FiniteDuration(config.getDuration("request-ttl", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
+
+  private var requestId: Short = 0
+
+  // A List is used over Vector here given the scans required in order to filter out expired elements.
+  private var requests = List.empty[(Short, CurrentRequest)]
+
+  private val resolvers: IndexedSeq[ActorRef] = nameServers.map({ ns =>
+    context.actorOf(Props(classOf[DnsClient], ns, self))
+  })(breakOut)
+
+  if (resolvers.nonEmpty)
+    log.info("Using the following DNS nameservers: {}", nameServers.mkString(", "))
+  else
+    log.warning("No DNS resolvers can be determined, either because of malformed configuration or perhaps an invalid /etc/resolv.conf if that's being used. Do not expect DNS names to be resolved.")
+
+  private def nextId(): Short = {
+    requestId = (requestId + 2).toShort
+    requestId
+  }
+
+  override def receive = {
+    case Dns.Resolve(name) if resolveSrv && isSrv(name) =>
+      val caseFoldedName = name.toLowerCase
+
+      cache.cached(caseFoldedName) match {
+        case Some(answer) =>
+          sender() ! answer
+        case None =>
+          val id = nextId()
+
+          requests =
+            requests.filter(_._2.expires.hasTimeLeft) :+
+              id -> CurrentRequest(
+                sender(),
+                caseFoldedName,
+                None,
+                None,
+                Some(Nil),
+                maxPositiveTtl,
+                requestTtl.fromNow)
+
+          resolvers(ThreadLocalRandom.current().nextInt(resolvers.length)) ! SrvQuestion(id, caseFoldedName)
+      }
+
+    case Dns.Resolve(name) =>
+      val caseFoldedName = name.toLowerCase
+
+      cache.cached(caseFoldedName) match {
+        case Some(answer) =>
+          sender() ! answer
+        case None if isInetAddress(name) =>
+          sender() ! Dns.Resolved(name, immutable.Seq(InetAddress.getByName(name)))
+        case None =>
+          val id = nextId()
+
+          requests =
+            requests.filter(_._2.expires.hasTimeLeft) :+
+              id -> CurrentRequest(
+                sender(),
+                caseFoldedName,
+                if (resolveIpv4) None else Some(Nil),
+                if (resolveIpv6) None else Some(Nil),
+                None,
+                maxPositiveTtl,
+                requestTtl.fromNow)
+
+          if (resolveIpv4) {
+            resolvers(ThreadLocalRandom.current().nextInt(resolvers.length)) ! Question4(id, caseFoldedName)
+          }
+          if (resolveIpv6) {
+            resolvers(ThreadLocalRandom.current().nextInt(resolvers.length)) ! Question6((id | 1).toShort, caseFoldedName)
+          }
+      }
+
+    case Answer(id, rrs) =>
+      val baseId = (id & ~1).toShort
+
+      val canonicalNames: Map[String, String] = rrs.collect({
+        case CNAMERecord(incomingName, _, canonicalName) =>
+          incomingName.toLowerCase -> canonicalName.toLowerCase
+      })(breakOut)
+
+      @tailrec
+      def resolveCanonicalName(name: String): String = {
+        canonicalNames.get(name) match {
+          case Some(canonicalName) => resolveCanonicalName(canonicalName)
+          case None => name
+        }
+      }
+
+      val rrsMinTtl = if (rrs.isEmpty) {
+        None
+      } else {
+        Some(rrs.map(_.ttl).min * 1000L)
+      }
+
+      requests = requests.find(_._1 == baseId) match {
+        case Some((_, req @ CurrentRequest(client, name, None, _, None, currentTtl, _))) if (id & 1) == 0 =>
+          val canonicalName = resolveCanonicalName(name)
+          val ttl = rrsMinTtl.fold(currentTtl)(math.min(currentTtl, _))
+          (baseId, req.copy(ipv4 = Some(rrs.collect({
+            case ARecord(incomingName, _, addr) if incomingName.toLowerCase == canonicalName =>
+              addr
+          })(breakOut)), ttl = ttl)) +: requests.filterNot(_._1 == baseId)
+        case Some((_, req @ CurrentRequest(client, name, _, None, None, currentTtl, _))) if (id & 1) == 1 =>
+          val canonicalName = resolveCanonicalName(name)
+          val ttl = rrsMinTtl.fold(currentTtl)(math.min(currentTtl, _))
+          (baseId, req.copy(ipv6 = Some(rrs.collect({
+            case AAAARecord(incomingName, _, addr) if incomingName.toLowerCase == canonicalName =>
+              addr
+          })(breakOut)), ttl = ttl)) +: requests.filterNot(_._1 == baseId)
+        case Some((_, req @ CurrentRequest(client, name, None, None, _, currentTtl, _))) =>
+          val canonicalName = resolveCanonicalName(name)
+          val ttl = rrsMinTtl.fold(currentTtl)(math.min(currentTtl, _))
+          val srv = rrs.collect({
+            case rec: SRVRecord if rec.name.toLowerCase == canonicalName =>
+              rec
+          })(breakOut)
+          (baseId, req.copy(srv = Some(srv), ttl = ttl)) +: requests.filterNot(_._1 == baseId)
+        case None =>
+          requests
+      }
+
+      requests = requests.find(_._1 == baseId) match {
+        case Some((_, CurrentRequest(client, name, Some(ipv4), Some(ipv6), None, recordsTtl, _))) =>
+          val ttl = if (ipv4.isEmpty && ipv6.isEmpty) {
+            negativeTtl
+          } else {
+            math.min(maxPositiveTtl, math.max(minPositiveTtl, recordsTtl))
+          }
+
+          cache.doPut(Dns.Resolved(name, ipv4, ipv6), ttl)
+          client ! Dns.Resolved(name, ipv4, ipv6)
+          requests.filterNot(_._1 == baseId)
+        case Some((_, CurrentRequest(client, name, None, None, Some(srv), recordsTtl, _))) =>
+          client ! SrvResolved(name, srv)
+          requests.filterNot(_._1 == baseId)
+        case _ =>
+          requests
+      }
+  }
+}
+
+object AsyncDnsResolver {
+  private val inetSocketAddress = """(.*?)(?::(\d+))?""".r
+
+  case class SrvResolved(name: String, srv: immutable.Seq[SRVRecord])
+
+  def parseNameserverAddress(str: String): InetSocketAddress = {
+    val inetSocketAddress(host, port) = str
+    new InetSocketAddress(host, Option(port).fold(53)(_.toInt))
+  }
+
+  private[asyncdns] def isSrv(name: String) =
+    name.nonEmpty && name(0) == '_'
+
+  private val ipv4Address = """^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$""".r
+  private val ipv6Address = """^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$""".r
+
+  private[asyncdns] def isInetAddress(name: String): Boolean =
+    ipv4Address.findAllMatchIn(name).nonEmpty || ipv6Address.findAllMatchIn(name).nonEmpty
+
+  // Note that the corresponding man page doesn't actually dictate the format of this field,
+  // just the keywords and their meanings. See http://man7.org/linux/man-pages/man5/resolv.conf.5.html
+  //
+  private[asyncdns] val NameserverLine = """^\s*nameserver\s+(.*)$""".r
+
+  // OS specific. No encoding or charset is specified by the man page as I recall.
+  // See http://man7.org/linux/man-pages/man5/resolv.conf.5.html.
+  //
+  def parseSystemNameServers(resolvConf: File): Option[immutable.Seq[InetSocketAddress]] =
+    try {
+      val addresses =
+        for {
+          line <- Source.fromFile(resolvConf).getLines()
+          addr <- NameserverLine.findFirstMatchIn(line).map(_.group(1))
+        } yield parseNameserverAddress(addr)
+      Some(addresses.toList)
+    } catch {
+      case NonFatal(_) => Option.empty
+    }
+
+  private[asyncdns] final case class CurrentRequest(
+    client: ActorRef,
+    name: String,
+    ipv4: Option[immutable.Seq[Inet4Address]],
+    ipv6: Option[immutable.Seq[Inet6Address]],
+    srv: Option[immutable.Seq[SRVRecord]],
+    ttl: Long,
+    expires: Deadline)
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/DnsClient.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/DnsClient.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.raw
+
+import java.net.{ InetAddress, InetSocketAddress }
+
+import akka.actor.{ Actor, ActorLogging, ActorRef, Stash }
+import akka.io.{ IO, Udp }
+
+class DnsClient(ns: InetSocketAddress, upstream: ActorRef) extends Actor with ActorLogging with Stash {
+
+  import context.system
+
+  IO(Udp) ! Udp.Bind(self, new InetSocketAddress(InetAddress.getByAddress(Array.ofDim(4)), 0))
+
+  def receive = {
+    case Udp.Bound(local) =>
+      log.debug(s"Bound to UDP address $local")
+      context.become(ready(sender()))
+      unstashAll()
+    case r: Question4 =>
+      stash()
+    case r: Question6 =>
+      stash()
+    case r: SrvQuestion =>
+      stash()
+  }
+
+  def ready(socket: ActorRef): Receive = {
+    {
+      case Question4(id, name) =>
+        log.debug(s"Resolving $name (A)")
+        val msg4 = Message(
+          id,
+          MessageFlags(recursionDesired = true),
+          Seq(
+            Question(name, RecordType.A, RecordClass.IN)))
+        log.debug(s"Message to $ns: $msg4")
+        socket ! Udp.Send(msg4.write(), ns)
+
+      case Question6(id, name) =>
+        log.debug(s"Resolving $name (AAAA)")
+        val msg6 = Message(
+          id,
+          MessageFlags(recursionDesired = true),
+          Seq(
+            Question(name, RecordType.AAAA, RecordClass.IN)))
+        log.debug(s"Message to $ns: $msg6")
+        socket ! Udp.Send(msg6.write(), ns)
+
+      case SrvQuestion(id, name) =>
+        log.debug(s"Resolving $name (SRV)")
+        val msg = Message(
+          id,
+          MessageFlags(recursionDesired = true),
+          Seq(
+            Question(name, RecordType.SRV, RecordClass.IN)))
+        log.debug(s"Message to $ns: $msg")
+        socket ! Udp.Send(msg.write(), ns)
+
+      case Udp.Received(data, remote) =>
+        log.debug(s"Received message from $remote: $data")
+        val msg = Message.parse(data)
+        log.debug(s"Decoded: $msg")
+        if (msg.flags.responseCode == ResponseCode.SUCCESS) {
+          upstream ! Answer(msg.id, msg.answerRecs)
+        } else {
+          upstream ! Answer(msg.id, Seq())
+        }
+
+      case Udp.Unbind => socket ! Udp.Unbind
+      case Udp.Unbound => context.stop(self)
+    }
+  }
+}
+
+case class SrvQuestion(id: Short, name: String)
+
+case class Question4(id: Short, name: String)
+
+case class Question6(id: Short, name: String)
+
+case class Answer(id: Short, rrs: Iterable[ResourceRecord])

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/DomainName.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/DomainName.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.raw
+
+import akka.util.{ ByteIterator, ByteString, ByteStringBuilder }
+
+object DomainName {
+  def length(name: String): Short = {
+    (name.length + 2).toShort
+  }
+
+  def write(it: ByteStringBuilder, name: String) {
+    for (label <- name.split('.')) {
+      it.putByte(label.length.toByte)
+      for (c <- label) {
+        it.putByte(c.toByte)
+      }
+    }
+    it.putByte(0)
+  }
+
+  def parse(it: ByteIterator, msg: ByteString): String = {
+    val ret = StringBuilder.newBuilder
+    //    ret.sizeHint(getNameLength(it.clone(), 0))
+    //    println("Parsing name")
+    while (true) {
+      val length = it.getByte
+      //      println(s"Label length: $length")
+
+      if (length == 0) {
+        val r = ret.result()
+        //        println(s"Name: $r")
+        return r
+      }
+
+      if (ret.nonEmpty)
+        ret.append('.')
+
+      if ((length & 0xc0) == 0xc0) {
+        val offset = ((length.toShort & 0x3f) << 8) | (it.getByte.toShort & 0x00ff)
+        //        println(s"Computed offset: $offset")
+        return ret.result() + parse(msg.iterator.drop(offset), msg)
+      }
+
+      ret.appendAll(it.clone().take(length).map(_.toChar))
+      it.drop(length)
+    }
+    ???
+  }
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/Message.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/Message.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.raw
+
+import akka.util.{ ByteString, ByteStringBuilder }
+
+object OpCode extends Enumeration {
+  val QUERY = Value(0)
+  val IQUERY = Value(1)
+  val STATUS = Value(2)
+}
+
+object ResponseCode extends Enumeration {
+  val SUCCESS = Value(0)
+  val FORMAT_ERROR = Value(1)
+  val SERVER_FAILURE = Value(2)
+  val NAME_ERROR = Value(3)
+  val NOT_IMPLEMENTED = Value(4)
+  val REFUSED = Value(5)
+}
+
+case class MessageFlags(flags: Short) extends AnyVal {
+  def isQuery: Boolean = (flags & 0x8000) == 0
+
+  def isAnswer = !isQuery
+
+  def opCode: OpCode.Value = OpCode((flags & 0x7800) >> 11)
+
+  def isAuthoritativeAnswer: Boolean = (flags & (1 << 10)) != 0
+
+  def isTruncated: Boolean = (flags & (1 << 9)) != 0
+
+  def isRecursionDesired: Boolean = (flags & (1 << 8)) != 0
+
+  def isRecursionAvailable: Boolean = (flags & (1 << 7)) != 0
+
+  def responseCode: ResponseCode.Value = {
+    ResponseCode(flags & 0x0f)
+  }
+
+  override def toString: String = {
+    var ret = List[String]()
+    ret +:= s"$responseCode"
+    if (isRecursionAvailable) ret +:= "RA"
+    if (isRecursionDesired) ret +:= "RD"
+    if (isTruncated) ret +:= "TR"
+    if (isAuthoritativeAnswer) ret +:= "AA"
+    ret +:= s"$opCode"
+    if (isAnswer) ret +:= "AN"
+    ret.mkString("<", ",", ">")
+  }
+}
+
+object MessageFlags {
+  def apply(answer: Boolean = false, opCode: OpCode.Value = OpCode.QUERY, authoritativeAnswer: Boolean = false,
+    truncated: Boolean = false, recursionDesired: Boolean = true, recursionAvailable: Boolean = false,
+    responseCode: ResponseCode.Value = ResponseCode.SUCCESS): MessageFlags = {
+    new MessageFlags((
+      (if (answer) 0x8000 else 0) |
+      (opCode.id << 11) |
+      (if (authoritativeAnswer) 1 << 10 else 0) |
+      (if (truncated) 1 << 9 else 0) |
+      (if (recursionDesired) 1 << 8 else 0) |
+      (if (recursionAvailable) 1 << 7 else 0) |
+      responseCode.id).toShort)
+  }
+}
+
+case class Message(
+  id: Short,
+  flags: MessageFlags,
+  questions: Seq[Question] = Seq.empty,
+  answerRecs: Seq[ResourceRecord] = Seq.empty,
+  authorityRecs: Seq[ResourceRecord] = Seq.empty,
+  additionalRecs: Seq[ResourceRecord] = Seq.empty) {
+  def write(): ByteString = {
+    val ret = ByteString.newBuilder
+    write(ret)
+    ret.result()
+  }
+
+  def write(ret: ByteStringBuilder): Unit = {
+    ret.putShort(id)
+      .putShort(flags.flags)
+      .putShort(questions.size)
+      .putShort(answerRecs.size)
+      .putShort(authorityRecs.size)
+      .putShort(additionalRecs.size)
+
+    questions.foreach(_.write(ret))
+    answerRecs.foreach(_.write(ret))
+    authorityRecs.foreach(_.write(ret))
+    additionalRecs.foreach(_.write(ret))
+  }
+}
+
+object Message {
+  def parse(msg: ByteString): Message = {
+    val it = msg.iterator
+    val id = it.getShort
+    val flags = it.getShort
+    val qdCount = it.getShort
+    val anCount = it.getShort
+    val nsCount = it.getShort
+    val arCount = it.getShort
+
+    val qs = (0 until qdCount) map { i => Question.parse(it, msg) }
+    val ans = (0 until anCount) map { i => ResourceRecord.parse(it, msg) }
+    val nss = (0 until nsCount) map { i => ResourceRecord.parse(it, msg) }
+    val ars = (0 until arCount) map { i => ResourceRecord.parse(it, msg) }
+
+    new Message(id, new MessageFlags(flags), qs, ans, nss, ars)
+  }
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/Question.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/Question.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.raw
+
+import akka.util.{ ByteIterator, ByteString, ByteStringBuilder }
+
+case class Question(name: String, qType: RecordType.Value, qClass: RecordClass.Value) {
+  def write(out: ByteStringBuilder) {
+    DomainName.write(out, name)
+    RecordType.write(out, qType)
+    RecordClass.write(out, qClass)
+  }
+}
+
+object Question {
+  def parse(it: ByteIterator, msg: ByteString): Question = {
+    val name = DomainName.parse(it, msg)
+    val qType = RecordType.parse(it)
+    val qClass = RecordClass.parse(it)
+    Question(name, qType, qClass)
+  }
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/RecordClass.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/RecordClass.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.raw
+
+import akka.util.{ ByteIterator, ByteStringBuilder }
+
+object RecordClass extends Enumeration {
+  val IN = Value(1)
+  val CS = Value(2)
+  val CH = Value(3)
+  val HS = Value(4)
+
+  val WILDCARD = Value(255)
+
+  def parse(it: ByteIterator): Value = {
+    RecordClass(it.getShort)
+  }
+
+  def write(out: ByteStringBuilder, c: Value): Unit = {
+    out.putShort(c.id)
+  }
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/RecordType.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/RecordType.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.raw
+
+import akka.util.{ ByteIterator, ByteStringBuilder }
+
+object RecordType extends Enumeration {
+  val A = Value(1)
+  val NS = Value(2)
+  val MD = Value(3)
+  val MF = Value(4)
+  val CNAME = Value(5)
+  val SOA = Value(6)
+  val MB = Value(7)
+  val MG = Value(8)
+  val MR = Value(9)
+  val NULL = Value(10)
+  val WKS = Value(11)
+  val PTR = Value(12)
+  val HINFO = Value(13)
+  val MINFO = Value(14)
+  val MX = Value(15)
+  val TXT = Value(16)
+  val AAAA = Value(28)
+  val SRV = Value(33)
+
+  val AXFR = Value(252)
+  val MAILB = Value(253)
+  val MAILA = Value(254)
+  val WILDCARD = Value(255)
+
+  def parse(it: ByteIterator): Value = {
+    RecordType(it.getShort)
+  }
+
+  def write(out: ByteStringBuilder, t: Value): Unit = {
+    out.putShort(t.id)
+  }
+}

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/ResourceRecord.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/ResourceRecord.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.raw
+
+import java.net.{ Inet4Address, Inet6Address, InetAddress }
+
+import akka.util.{ ByteIterator, ByteString, ByteStringBuilder }
+
+sealed abstract class ResourceRecord(val name: String, val ttl: Int, val recType: Short, val recClass: Short) {
+  def write(it: ByteStringBuilder): Unit = {
+    DomainName.write(it, name)
+    it.putShort(recType)
+    it.putShort(recClass)
+  }
+}
+
+case class ARecord(override val name: String, override val ttl: Int,
+  ip: Inet4Address) extends ResourceRecord(name, ttl, RecordType.A.id.toShort, RecordClass.IN.id.toShort) {
+  override def write(it: ByteStringBuilder): Unit = {
+    super.write(it)
+    val addr = ip.getAddress
+    it.putShort(addr.length)
+    it.putBytes(addr)
+  }
+}
+
+object ARecord {
+  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator): ARecord = {
+    val addr = Array.ofDim[Byte](4)
+    it.getBytes(addr)
+    ARecord(name, ttl, InetAddress.getByAddress(addr).asInstanceOf[Inet4Address])
+  }
+}
+
+case class AAAARecord(override val name: String, override val ttl: Int,
+  ip: Inet6Address) extends ResourceRecord(name, ttl, RecordType.AAAA.id.toShort, RecordClass.IN.id.toShort) {
+  override def write(it: ByteStringBuilder): Unit = {
+    super.write(it)
+    val addr = ip.getAddress
+    it.putShort(addr.length)
+    it.putBytes(addr)
+  }
+}
+
+object AAAARecord {
+  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator): AAAARecord = {
+    val addr = Array.ofDim[Byte](16)
+    it.getBytes(addr)
+    AAAARecord(name, ttl, InetAddress.getByAddress(addr).asInstanceOf[Inet6Address])
+  }
+}
+
+case class CNAMERecord(override val name: String, override val ttl: Int,
+  canonicalName: String) extends ResourceRecord(name, ttl, RecordType.CNAME.id.toShort, RecordClass.IN.id.toShort) {
+  override def write(it: ByteStringBuilder): Unit = {
+    super.write(it)
+    it.putShort(DomainName.length(name))
+    DomainName.write(it, name)
+  }
+}
+
+object CNAMERecord {
+  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator, msg: ByteString): CNAMERecord = {
+    CNAMERecord(name, ttl, DomainName.parse(it, msg))
+  }
+}
+
+case class SRVRecord(override val name: String, override val ttl: Int,
+  priority: Int, weight: Int, port: Int, target: String) extends ResourceRecord(name, ttl, RecordType.SRV.id.toShort, RecordClass.IN.id.toShort) {
+  override def write(it: ByteStringBuilder): Unit = {
+    super.write(it)
+    it.putShort(priority)
+    it.putShort(weight)
+    it.putShort(port)
+    DomainName.write(it, target)
+  }
+}
+
+object SRVRecord {
+  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator, msg: ByteString): SRVRecord = {
+    val priority = it.getShort
+    val weight = it.getShort
+    val port = it.getShort
+    SRVRecord(name, ttl, priority, weight, port, DomainName.parse(it, msg))
+  }
+}
+
+case class UnknownRecord(override val name: String, override val ttl: Int,
+  override val recType: Short, override val recClass: Short,
+  data: ByteString) extends ResourceRecord(name, ttl, recType, recClass) {
+  override def write(it: ByteStringBuilder): Unit = {
+    super.write(it)
+    it.putShort(data.length)
+    it.append(data)
+  }
+}
+
+object UnknownRecord {
+  def parseBody(name: String, ttl: Int, recType: Short, recClass: Short, length: Short, it: ByteIterator): UnknownRecord = {
+    UnknownRecord(name, ttl, recType, recClass, it.toByteString)
+  }
+}
+
+object ResourceRecord {
+  def parse(it: ByteIterator, msg: ByteString): ResourceRecord = {
+    val name = DomainName.parse(it, msg)
+    val recType = it.getShort
+    val recClass = it.getShort
+    val ttl = it.getInt
+    val rdLength = it.getShort
+    val data = it.clone().take(rdLength)
+    it.drop(rdLength)
+    recType match {
+      case 1 =>
+        ARecord.parseBody(name, ttl, rdLength, data)
+      case 5 =>
+        CNAMERecord.parseBody(name, ttl, rdLength, data, msg)
+      case 28 =>
+        AAAARecord.parseBody(name, ttl, rdLength, data)
+      case 33 =>
+        SRVRecord.parseBody(name, ttl, rdLength, data, msg)
+      case _ =>
+        UnknownRecord.parseBody(name, ttl, recType, recClass, rdLength, data)
+    }
+  }
+}
+

--- a/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/package.scala
+++ b/async-dns/src/main/scala/com/lightbend/rp/asyncdns/raw/package.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns
+
+import java.nio.ByteOrder
+
+package object raw {
+  implicit val networkByteOrder = ByteOrder.BIG_ENDIAN
+}

--- a/async-dns/src/test/scala/com/lightbend/rp/asyncdns/dns/AsyncDnsResolverSpec.scala
+++ b/async-dns/src/test/scala/com/lightbend/rp/asyncdns/dns/AsyncDnsResolverSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.dns
+
+import akka.io.{ Dns, IO }
+import akka.pattern.ask
+import akka.util.Timeout
+import com.lightbend.rp.asyncdns.AsyncDnsResolver
+import java.io.File
+import java.net.InetAddress
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+import AsyncDnsResolver.SrvResolved
+
+class AsyncDnsResolverSpec extends AsyncDnsSpec(
+  """
+    akka.io.dns.resolver = async-dns
+    akka.io.dns.async-dns.nameservers = ["8.8.8.8", "8.8.4.4"]
+    akka.io.dns.async-dns.resolve-srv = true
+  """) {
+  val duration = Duration(10, TimeUnit.SECONDS)
+  implicit val timeout = Timeout(duration)
+
+  "Resolver" should {
+    "resolve single A record" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("a-single.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("a-single.test.smslv.ru")
+      answer.ipv4 should equal(Seq(InetAddress.getByName("1.4.32.128")))
+      answer.ipv6 should be(empty)
+    }
+    "resolve double A records" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("a-double.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("a-double.test.smslv.ru")
+      answer.ipv4.toSet should equal(Set(
+        InetAddress.getByName("1.4.32.128"), InetAddress.getByName("2.8.16.64")))
+      answer.ipv6 should be(empty)
+    }
+    "resolve single AAAA record" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("aaaa-single.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("aaaa-single.test.smslv.ru")
+      answer.ipv6 should equal(Seq(InetAddress.getByName("2001:0db8:85a3:0:0:8a2e:0370:7334")))
+      answer.ipv4 should be(empty)
+    }
+    "resolve double AAAA records" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("aaaa-double.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("aaaa-double.test.smslv.ru")
+      answer.ipv6.toSet should equal(Set(
+        InetAddress.getByName("2001:0db8:85a3:0:0:8a2e:0370:7334"),
+        InetAddress.getByName("fe80:0:0:0:202:b3ff:fe1e:8329")))
+      answer.ipv4 should be(empty)
+    }
+    "resolve mixed A/AAAA records" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("a+aaaa.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("a+aaaa.test.smslv.ru")
+      answer.ipv4.toSet should equal(Set(
+        InetAddress.getByName("1.4.32.128"), InetAddress.getByName("2.8.16.64")))
+      answer.ipv6.toSet should equal(Set(
+        InetAddress.getByName("2001:0db8:85a3:0:0:8a2e:0370:7334"),
+        InetAddress.getByName("fe80:0:0:0:202:b3ff:fe1e:8329")))
+    }
+    "resolve external CNAME record" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("cname-ext.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("cname-ext.test.smslv.ru")
+      answer.ipv4.toSet should equal(Set(
+        InetAddress.getByName("1.4.32.128")))
+      answer.ipv6.toSet should be(empty)
+    }
+    "resolve internal CNAME record" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("cname-int.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("cname-int.test.smslv.ru")
+      answer.ipv4.toSet should equal(Set(
+        InetAddress.getByName("1.4.32.128"), InetAddress.getByName("2.8.16.64")))
+      answer.ipv6.toSet should be(empty)
+    }
+    "resolve SRV record" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("_http._tcp.smslv.ru"), duration).asInstanceOf[SrvResolved]
+      answer.name should equal("_http._tcp.smslv.ru")
+      answer.srv.head.name should equal("_http._tcp.smslv.ru")
+      answer.srv.head.priority should equal(10)
+      answer.srv.head.port should equal(80)
+      answer.srv.head.target should equal("a-single.test.smslv.ru")
+    }
+    "resolve same address twice" in {
+      def resolve() = {
+        Await.result(IO(Dns) ? Dns.Resolve("a-single.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      }
+      resolve().ipv4 should equal(Seq(InetAddress.getByName("1.4.32.128")))
+      resolve().ipv4 should equal(Seq(InetAddress.getByName("1.4.32.128")))
+    }
+    "handle nonexistent domains" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("nonexistent.test.smslv.ru"), duration).asInstanceOf[Dns.Resolved]
+      answer.ipv4 should be(empty)
+      answer.ipv6 should be(empty)
+    }
+    "resolve an IPV4 to an IP" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("1.4.32.128"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("1.4.32.128")
+      answer.ipv4 should equal(Seq(InetAddress.getByName("1.4.32.128")))
+      answer.ipv6 should be(empty)
+    }
+    "resolve an IPV6 to an IP" in {
+      val answer = Await.result(IO(Dns) ? Dns.Resolve("1080:0:0:0:8:800:200C:4171"), duration).asInstanceOf[Dns.Resolved]
+      answer.name should equal("1080:0:0:0:8:800:200C:4171")
+      answer.ipv4 should be(empty)
+      answer.ipv6 should equal(Seq(InetAddress.getByName("1080:0:0:0:8:800:200C:4171")))
+    }
+  }
+
+  "Resolver functions" should {
+    "parse a resolv.conf file successfully" in {
+      val resolvConf = Files.createTempFile("resolve", "conf").toFile
+      resolvConf.deleteOnExit()
+      Files.write(
+        resolvConf.toPath,
+        """# This file is automatically generated.
+          |#
+          |search lan
+          |nameserver 10.0.1.1
+          |nameserver 2001:44b8:3127:3500::1
+          |
+        """.stripMargin.getBytes)
+      AsyncDnsResolver.parseSystemNameServers(resolvConf) should be(Some(List(
+        AsyncDnsResolver.parseNameserverAddress("10.0.1.1"),
+        AsyncDnsResolver.parseNameserverAddress("2001:44b8:3127:3500::1"))))
+    }
+
+    "return an empty list when a resolv.conf file has no nameservers" in {
+      val resolvConf = Files.createTempFile("resolve", "conf").toFile
+      resolvConf.deleteOnExit()
+      Files.write(
+        resolvConf.toPath,
+        """# This file is automatically generated.
+          |#
+          |search lan
+        """.stripMargin.getBytes)
+      AsyncDnsResolver.parseSystemNameServers(resolvConf) should be(Some(List.empty))
+    }
+
+    "return an empty list when a resolv.conf file has a single nameserver with no address" in {
+      val resolvConf = Files.createTempFile("resolve", "conf").toFile
+      resolvConf.deleteOnExit()
+      Files.write(
+        resolvConf.toPath,
+        """# This file is automatically generated.
+          |#
+          |nameserver
+        """.stripMargin.getBytes)
+      AsyncDnsResolver.parseSystemNameServers(resolvConf) should be(Some(List.empty))
+    }
+
+    "return nothing when there is no resolv.conf" in {
+      val resolvConf = new File("something-somewhere")
+      AsyncDnsResolver.parseSystemNameServers(resolvConf) should be(None)
+    }
+  }
+}

--- a/async-dns/src/test/scala/com/lightbend/rp/asyncdns/dns/AsyncDnsSpec.scala
+++ b/async-dns/src/test/scala/com/lightbend/rp/asyncdns/dns/AsyncDnsSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.dns
+
+import akka.actor.ActorSystem
+import akka.dispatch.Dispatchers
+import akka.event.{ Logging, LoggingAdapter }
+import akka.testkit._
+import akka.testkit.TestEvent._
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import scala.concurrent.Future
+import scala.language.{ postfixOps, reflectiveCalls }
+
+object AsyncDnsSpec {
+  val testConf: Config = ConfigFactory.parseString(
+    """
+      akka {
+        loggers = ["akka.testkit.TestEventListener"]
+        loglevel = "WARNING"
+        stdout-loglevel = "WARNING"
+        actor {
+          default-dispatcher {
+            executor = "fork-join-executor"
+            fork-join-executor {
+              parallelism-min = 8
+              parallelism-factor = 2.0
+              parallelism-max = 8
+            }
+          }
+        }
+      }
+    """)
+
+  def mapToConfig(map: Map[String, AnyRef]): Config = {
+    import scala.collection.JavaConverters._
+    ConfigFactory.parseMap(map.asJava)
+  }
+
+  def getCallerName(clazz: Class[_]): String = {
+    val s = (Thread.currentThread.getStackTrace map (_.getClassName) drop 1)
+      .dropWhile(_ matches "(java.lang.Thread|.*AsyncDnsSpec.?$)")
+    val reduced = s.lastIndexWhere(_ == clazz.getName) match {
+      case -1 ⇒ s
+      case z ⇒ s drop (z + 1)
+    }
+    reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
+  }
+
+}
+
+abstract class AsyncDnsSpec(_system: ActorSystem)
+  extends TestKit(_system) with WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  def this(config: Config) = this(ActorSystem(
+    AsyncDnsSpec.getCallerName(getClass),
+    ConfigFactory.load(config.withFallback(AsyncDnsSpec.testConf))))
+
+  def this(s: String) = this(ConfigFactory.parseString(s))
+
+  def this(configMap: Map[String, AnyRef]) = this(AsyncDnsSpec.mapToConfig(configMap))
+
+  def this() = this(ActorSystem(AsyncDnsSpec.getCallerName(getClass), AsyncDnsSpec.testConf))
+
+  val log: LoggingAdapter = Logging(system, this.getClass)
+
+  override val invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
+
+  final override def beforeAll() {
+    atStartup()
+  }
+
+  final override def afterAll() {
+    beforeTermination()
+    shutdown()
+    afterTermination()
+  }
+
+  protected def atStartup() {}
+
+  protected def beforeTermination() {}
+
+  protected def afterTermination() {}
+
+  def spawn(dispatcherId: String = Dispatchers.DefaultDispatcherId)(body: ⇒ Unit): Unit =
+    Future(body)(system.dispatchers.lookup(dispatcherId))
+
+  def muteDeadLetters(messageClasses: Class[_]*)(sys: ActorSystem = system): Unit =
+    if (!sys.log.isDebugEnabled) {
+      def mute(clazz: Class[_]): Unit =
+        sys.eventStream.publish(Mute(DeadLettersFilter(clazz)(occurrences = Int.MaxValue)))
+      if (messageClasses.isEmpty) mute(classOf[AnyRef])
+      else messageClasses foreach mute
+    }
+
+}

--- a/async-dns/src/test/scala/com/lightbend/rp/asyncdns/dns/NameserverAddressParserSpec.scala
+++ b/async-dns/src/test/scala/com/lightbend/rp/asyncdns/dns/NameserverAddressParserSpec.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2016 Ilya Epifanov
+ */
+
+package com.lightbend.rp.asyncdns.dns
+
+import com.lightbend.rp.asyncdns.AsyncDnsResolver
+import java.net.InetSocketAddress
+import org.scalatest.{ Matchers, WordSpec }
+
+class NameserverAddressParserSpec extends WordSpec with Matchers {
+  "Parser" should {
+    "handle explicit port in IPv4 address" in {
+      AsyncDnsResolver.parseNameserverAddress("8.8.8.8:153") should equal(new InetSocketAddress("8.8.8.8", 153))
+    }
+    "handle explicit port in IPv6 address" in {
+      AsyncDnsResolver.parseNameserverAddress("[2001:4860:4860::8888]:153") should equal(new InetSocketAddress("2001:4860:4860::8888", 153))
+    }
+    "handle default port in IPv4 address" in {
+      AsyncDnsResolver.parseNameserverAddress("8.8.8.8") should equal(new InetSocketAddress("8.8.8.8", 53))
+    }
+    "handle default port in IPv6 address" in {
+      AsyncDnsResolver.parseNameserverAddress("[2001:4860:4860::8888]") should equal(new InetSocketAddress("2001:4860:4860::8888", 53))
+    }
+  }
+}

--- a/service-discovery/src/main/resources/rp-tooling.conf
+++ b/service-discovery/src/main/resources/rp-tooling.conf
@@ -1,4 +1,4 @@
-# TODO: This config should be generated at runtime as it is platform-specific, or tooling needs platform-specific
+# TODO: This config should be generated at runtime as it is platform-specific, or this project needs platform-specific
 # configs that are included dynamically depending upon platform, perhaps via -Dconfig.resource
 
 akka {
@@ -6,10 +6,7 @@ akka {
     dns {
       resolver = async-dns
       async-dns {
-        # FIXME: temporarily disable this until we sort out the issue around shaded Akka DNS dependency
-        # This has to be set to the name of the shaded class
-        # provider-object = "com.lightbend.rp.internal.ru.smslv.akka.dns.AsyncDnsProvider"
-        provider-object = "ru.smslv.akka.dns.AsyncDnsProvider"
+        provider-object = "com.lightbend.rp.asyncdns.AsyncDnsProvider"
         resolve-srv = true
         resolv-conf = on
       }

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
@@ -17,19 +17,19 @@
 package com.lightbend.rp.servicediscovery.scaladsl
 
 import akka.actor._
-import akka.io.AsyncDnsResolver.SrvResolved
 import akka.io.Dns.Resolved
 import akka.io.{ Dns, IO }
 import akka.pattern.ask
+import com.lightbend.rp.asyncdns.AsyncDnsResolver
+import com.lightbend.rp.asyncdns.raw.SRVRecord
 import com.lightbend.rp.common._
 import com.lightbend.rp.servicediscovery.scaladsl.ServiceLocatorLike.{ AddressSelection, AddressSelectionRandom }
 import java.net.URI
 import java.util.concurrent.ThreadLocalRandom
-
-import ru.smslv.akka.dns.raw.SRVRecord
-
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
+
+import AsyncDnsResolver.SrvResolved
 
 case class ServiceLocator(as: ActorSystem) {
   def lookupOne(namespace: String, name: String, endpoint: String): Future[Option[Service]] =

--- a/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/javadsl/ServiceLocatorSpec.scala
+++ b/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/javadsl/ServiceLocatorSpec.scala
@@ -22,9 +22,7 @@ import com.lightbend.rp.servicediscovery.scaladsl.{ Service, Settings }
 import com.typesafe.config.ConfigFactory
 import java.net.URI
 import java.util.Optional
-
 import org.scalatest.{ AsyncWordSpecLike, BeforeAndAfterAll, Matchers }
-
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 

--- a/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
+++ b/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
@@ -17,16 +17,15 @@
 package com.lightbend.rp.servicediscovery.scaladsl
 
 import akka.actor.{ ActorRef, ActorSystem }
+import akka.io.Dns
 import akka.testkit.{ ImplicitSender, TestKit, TestProbe }
+import com.lightbend.rp.asyncdns.AsyncDnsResolver
+import com.lightbend.rp.asyncdns.raw.SRVRecord
+import com.lightbend.rp.common.{ Kubernetes, Platform }
 import com.typesafe.config.ConfigFactory
 import java.net.{ InetAddress, URI }
-
-import akka.io.{ AsyncDnsResolver, Dns }
-import com.lightbend.rp.common.{ Kubernetes, Platform }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ AsyncWordSpecLike, BeforeAndAfterAll, Inside, Matchers }
-import ru.smslv.akka.dns.raw.SRVRecord
-
 import scala.collection.immutable.Seq
 
 object ServiceLocatorSpec {


### PR DESCRIPTION
This imports [akka-dns](https://github.com/ilya-epifanov/akka-dns) as a subproject that our service locator uses for its DNS SRV lookups.

I considered making it part of the project setup, but given that the upstream project isn't actively maintained I think it's better for us to own this code.

This supplants the need for #34