### PR TITLE
No longer enable Lagom Java service locator by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 An application library that is a component of [Lightbend Platform Tooling](https://s3-us-west-2.amazonaws.com/rp-tooling-temp-docs/home.html),
 a project aimed at making it easier to deploy to orchestrated environments like Kubernetes.
 
+## Usage
+
+This project is included in your application by [sbt-reactive-app](https://github.com/lightbend/sbt-reactive-app). Consult
+the [Lightbend Platform Tooling](https://s3-us-west-2.amazonaws.com/rp-tooling-temp-docs/home.html) documentation
+for setup and configuration.
+
 ## Maintenance
 
 Enterprise Suite Platform Team <es-platform@lightbend.com>

--- a/service-discovery-lagom14-java/src/main/resources/rp-tooling.conf
+++ b/service-discovery-lagom14-java/src/main/resources/rp-tooling.conf
@@ -1,1 +1,0 @@
-play.modules.enabled += "com.lightbend.rp.servicediscovery.lagom.javadsl.ServiceLocatorModule"


### PR DESCRIPTION
For parity with the Scala, this ensures that we don't enable the Java service locator by default.

We document how to use it in the Platform Tooling docs, see: https://github.com/lightbend/platform-tooling-docs/pull/19

Also relevant is https://github.com/lightbend/service-locator-dns/issues/22, which should probably be modified in a similar manner.