### PR TITLE
Change visibility on healthy/readiness methods

### DIFF
--- a/status/src/main/scala/com/lightbend/rp/status/ApplicationStatus.scala
+++ b/status/src/main/scala/com/lightbend/rp/status/ApplicationStatus.scala
@@ -55,12 +55,12 @@ class ApplicationStatus(system: ExtendedActorSystem) extends Extension with Mana
       path("ready")(complete(isReady.map(r => if (r) StatusCodes.OK else StatusCodes.ServiceUnavailable))))
   }
 
-  private def isHealthy(implicit ec: ExecutionContext): Future[Boolean] =
+  def isHealthy(implicit ec: ExecutionContext): Future[Boolean] =
     Future
       .sequence(healthChecks.map(_.healthy(system)))
       .map(_.forall(identity))
 
-  private def isReady(implicit ec: ExecutionContext): Future[Boolean] =
+  def isReady(implicit ec: ExecutionContext): Future[Boolean] =
     Future
       .sequence(readinessChecks.map(_.ready(system)))
       .map(_.forall(identity))


### PR DESCRIPTION
Allows user to use status APIs for their own purposes, e.g. maybe they want to expose readiness/health info endpoints on the Play server instead of akka-management.