### PR TITLE
Implement mesos support for service locator

### DIFF
--- a/common/src/main/scala/com/lightbend/rp/common/Platform.scala
+++ b/common/src/main/scala/com/lightbend/rp/common/Platform.scala
@@ -20,11 +20,14 @@ sealed trait Platform
 
 case object Kubernetes extends Platform
 
+case object Mesos extends Platform
+
 object Platform {
   lazy val active: Option[Platform] = decode(sys.env.get("RP_PLATFORM"))
 
   private[rp] def decode(platform: Option[String]) = platform match {
     case Some("kubernetes") => Some(Kubernetes)
+    case Some("mesos") => Some(Mesos)
     case _ => None
   }
 }


### PR DESCRIPTION
This modifies the service locator to understand conventions for Mesos DNS SRV addresses. 

Manually tested on DC/OS with Chirper via this PR: https://github.com/lagom/lagom-java-maven-chirper-example/pull/4