### PR TITLE
More DC/OS fixes

### DIFF
--- a/akka-management/src/main/resources/rp-tooling.conf
+++ b/akka-management/src/main/resources/rp-tooling.conf
@@ -3,8 +3,10 @@ akka {
 
   management {
     http {
-      hostname = ${?RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST}
-      port = ${?RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT}
+      hostname = ${?RP_ENDPOINT_AKKA_MGMT_HTTP_HOST}
+      port = ${?RP_ENDPOINT_AKKA_MGMT_HTTP_PORT}
+      bind-hostname = ${?RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST}
+      bind-port = ${?RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT}
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,7 @@ lazy val akkaClusterBootstrap = createProject("reactive-lib-akka-cluster-bootstr
   .settings(
     libraryDependencies ++= Seq(
       "com.lightbend.akka.discovery"  %% "akka-discovery-kubernetes-api"     % Versions.akkaManagement,
+      "com.lightbend.akka.discovery"  %% "akka-discovery-marathon-api"       % Versions.akkaManagement,
       "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % Versions.akkaManagement,
       "com.typesafe.akka"             %% "akka-testkit"                      % Versions.akka              % "test",
       "com.typesafe.akka"             %% "akka-cluster"                      % Versions.akka              % "provided"

--- a/service-discovery/src/main/resources/reference.conf
+++ b/service-discovery/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 com.lightbend.platform-tooling {
   service-discovery {
-    ask-timeout = 1 second
+    ask-timeout = 5 seconds
 
     external-service-addresses {
     #  "my-service/my-endpoint" {
@@ -9,5 +9,7 @@ com.lightbend.platform-tooling {
     }
 
     external-service-address-limit = 3
+
+    retry-delays = [100 milliseconds, 500 milliseconds, 1 second]
   }
 }

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Settings.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/Settings.scala
@@ -41,6 +41,13 @@ final class Settings(system: ExtendedActorSystem) extends Extension {
 
   val externalServiceAddressLimit: Int = serviceDiscovery.getInt("external-service-address-limit")
 
+  val retryDelays: Seq[FiniteDuration] =
+    serviceDiscovery
+      .getDurationList("retry-delays", MILLISECONDS)
+      .asScala
+      .toVector
+      .map(Duration(_, MILLISECONDS))
+
   private def duration(config: Config, key: String): FiniteDuration =
     Duration(config.getDuration(key, MILLISECONDS), MILLISECONDS)
 }


### PR DESCRIPTION
Contains a few fixes that improve running under DC/OS, notably:

* include dep for akka-mangement marathon-api
* fix env var names used for akka-management config so that bridge networking works
* retry dns lookups (as [akka-dns](https://github.com/ilya-epifanov/akka-dns) doesn't retry, and DNS is UDP)
* loosen ask timeout for service locator, as 1 second is a bit too tight esp. when a service has just been started and hotspots haven't been jitd yet