### PR TITLE
Update Akka Management to 0.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import ReleaseTransformations._
 lazy val Versions = new {
   val akka                      = "2.5.7"
   val akkaDns                   = "2.4.2"
-  val akkaManagement            = "0.9.0"
+  val akkaManagement            = "0.13.0"
   val lagom14                   = "1.4.0"
   val play25                    = "2.5.0"
   val play26                    = "2.6.0"


### PR DESCRIPTION
Fixes #57 

Notable changes:

- The default akka-management port is now 8558, instead of 19999 (this is more consistent now than before, which was accidental that we had the 1999 value there in a few places)
- Management bind port and fallback port of contact points should default to the same
- Add a "Role-Based Access Control" heading
- additional logging info
- Documentation: Kuberentes API Akka remoting port
- Spell out Akka 2.5 requirement in docs
- AsyncEcsSimpleServiceDiscovery -- listTaskArns needs a cluster name
- ECS service discovery improvements

Full details about changes: https://github.com/akka/akka-management/milestone/12?closed=1

