### PR TITLE
Support alternate Kubernetes cluster DNS suffixes from environment

### DIFF
--- a/common/src/main/scala/com/lightbend/rp/common/kubernetes/package.scala
+++ b/common/src/main/scala/com/lightbend/rp/common/kubernetes/package.scala
@@ -18,4 +18,5 @@ package com.lightbend.rp.common
 
 package object kubernetes {
   val DefaultNamespace: String = "default"
+  val DefaultSuffix: String = "cluster.local"
 }

--- a/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
+++ b/service-discovery/src/main/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocator.scala
@@ -100,11 +100,12 @@ trait ServiceLocatorLike {
           name
         } else {
           val serviceNamespace = namespace.orElse(namespaceFromEnv()).getOrElse(kubernetes.DefaultNamespace)
+          val clusterSuffix = suffixFromEnv().getOrElse(kubernetes.DefaultSuffix)
           val serviceName = endpointServiceName(name)
           val endpointName = endpointServiceName(endpoint)
 
           // @TODO hardcoded _tcp
-          s"_$endpointName._tcp.$serviceName.$serviceNamespace.svc.cluster.local"
+          s"_$endpointName._tcp.$serviceName.$serviceNamespace.svc.$clusterSuffix"
         }
 
       case Some(Mesos) =>
@@ -293,6 +294,10 @@ trait ServiceLocatorLike {
 
   protected def namespaceFromEnv(): Option[String] =
     env.get("RP_NAMESPACE")
+
+  protected def suffixFromEnv(): Option[String] = {
+    env.get("RP_KUBERNETES_CLUSTER_SUFFIX")
+  }
 
   private def endpointServiceName(name: String): String =
     name

--- a/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
+++ b/service-discovery/src/test/scala/com/lightbend/rp/servicediscovery/scaladsl/ServiceLocatorSpec.scala
@@ -167,6 +167,12 @@ class ServiceLocatorSpec extends TestKit(ActorSystem("service-locator", ServiceL
           result shouldBe "_api._tcp.friendservice.cake.svc.cluster.local"
         }
 
+        "translate name with namespace from env + name + endpoint + suffix" in {
+          val serviceLocator = createServiceLocator(Kubernetes, Map("RP_NAMESPACE" -> "cake", "RP_KUBERNETES_CLUSTER_SUFFIX" -> "new.kube"))
+          val result = serviceLocator.translateName(namespace = None, "friendservice", "api")
+          result shouldBe "_api._tcp.friendservice.cake.svc.new.kube"
+        }
+
         "translate name with default namespace + name + endpoint" in {
           val serviceLocator = createServiceLocator(Kubernetes)
           val result = serviceLocator.translateName(namespace = None, "friendservice", "api")


### PR DESCRIPTION
Should fix #62 

Major changes:
- Override of default k8s cluster dns suffix ("cluster.local") by setting environment var RP_KUBERNETES_CLUSTER_SUFFIX
- Falls back to default suffix if not set
- Default suffix set in kubernetes companion object - where I saw that the default k8s namespace is also set

Did not update version - assumed that would be set if the PR was accepted.  Apologies if this is in error.
