### PR TITLE
Downgrade the Akka HTTP to 10.0.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 
 lazy val Versions = new {
   val akka                      = "2.5.18"
-  val akkaHttp                  = "10.1.5"
+  val akkaHttp                  = "10.0.15"
   val akkaManagement            = "0.20.0"
   val lagom14                   = "1.4.0"
   val play25                    = "2.5.0"


### PR DESCRIPTION
Ref #104, #103
Ref https://discuss.lightbend.com/t/no-configuration-setting-found-for-key-decode-max-size/2738
Ref lagom/lagom#1652

As per recommendation by Play/Lagom team, I am downgrading the Akka HTTP to 10.0.15, which aligns with Lagom 1.4.x, as opposed to 10.1.5 that's compatible with Lagom 1.5.x.

/cc @lightbend/play-lagom 