### PR TITLE
Deprecate SecretReader

### DIFF
--- a/secrets/src/main/java/com/lightbend/rp/secrets/javadsl/SecretReader.java
+++ b/secrets/src/main/java/com/lightbend/rp/secrets/javadsl/SecretReader.java
@@ -26,6 +26,10 @@ import scala.compat.java8.FutureConverters;
 import scala.compat.java8.OptionConverters;
 
 public class SecretReader {
+    /**
+     * @deprecated  As of 1.7.0. Read from file /rp/secrets/%name%/%key% where %name% is transformed to lowercase, and '-' for non-alphanum.
+     */
+    @Deprecated
     public static CompletionStage<Optional<ByteString>> get(String name, String key, ActorSystem actorSystem, ActorMaterializer mat) {
         return FutureConverters.toJava(
                 SecretReader$

--- a/secrets/src/main/scala/com/lightbend/rp/secrets/scaladsl/SecretReader.scala
+++ b/secrets/src/main/scala/com/lightbend/rp/secrets/scaladsl/SecretReader.scala
@@ -27,6 +27,7 @@ import java.nio.file.{ Path, Paths }
 import scala.concurrent._
 
 object SecretReader {
+  @deprecated("Read from file /rp/secrets/%name%/%key% where %name% is transformed to lowercase, and '-' for non-alphanum", "1.7.0")
   def get(name: String, key: String)(implicit as: ActorSystem, mat: ActorMaterializer): Future[Option[ByteString]] = {
     import as.dispatcher
 


### PR DESCRIPTION
Fixes #113

SecretReader reads from the secret files that reactive-cli mounts as volume.
This deprecates that so the users can read it themselves.

/cc @lightbend/play-lagom 